### PR TITLE
Add workaround + error message if we end up in a crossfade scenario w…

### DIFF
--- a/client_generic/Client/Player.cpp
+++ b/client_generic/Client/Player.cpp
@@ -620,6 +620,10 @@ bool CPlayer::Update(uint32_t displayUnit)
                 if (m_currentClip && m_currentClip->IsFadingOut()) {
                     g_Log->Info("PND : Standard crossfading");
                     PlayNextDream();
+                } else if (m_currentClip && m_currentClip->HasFinished() && !m_isTransitioning) {
+                    // Safety catch: clip finished without proper fading
+                    g_Log->Error("Clip finished without fading out state, forcing transition");
+                    PlayNextDream();
                 }
             }
         }


### PR DESCRIPTION
…here we never start the transition

Should we reach end of the video without being  in a transition as expected now, we just go to the next dream as a workaround