### PR TITLE
Fix streaming not saving correctly to cache

### DIFF
--- a/client_generic/ContentDecoder/ContentDecoder.h
+++ b/client_generic/ContentDecoder/ContentDecoder.h
@@ -172,9 +172,13 @@ class CContentDecoder
     void CloseCacheFile();
     void WriteToCache(const uint8_t* buf, int buf_size, int64_t position);
     std::string GenerateCacheFileName();
+    std::string GetFinalFileName() const;
     
     bool IsDownloadComplete() const;
     void FinalizeCacheFile();
+    
+    // Static mutex to ensure atomic file renaming across all instances
+    static std::mutex s_RenameMutex;
 };
 
 MakeSmartPointers(CContentDecoder);


### PR DESCRIPTION
- Fix positioning (ffmpeg writes the metadata at the end of the file early on then seeks back)
- Use better flushing on macOS to avoid any fsync issue
- Add thread pid to tmp filename to ensure we're never having two threads working on the same file and messing things up