### PR TITLE
Clamp perceptual FPS

### DIFF
--- a/client_generic/Client/Player.cpp
+++ b/client_generic/Client/Player.cpp
@@ -25,6 +25,7 @@
 #include "base.h"
 #include "clientversion.h"
 
+
 #ifdef WIN32
 //#include "DisplayD3D12.h"
 //#include "RendererD3D12.h"
@@ -82,6 +83,17 @@ using CClip = ContentDecoder::CClip;
 using spCClip = ContentDecoder::spCClip;
 typedef std::shared_lock<std::shared_mutex> reader_lock;
 typedef std::unique_lock<std::shared_mutex> writer_lock;
+
+namespace
+{
+constexpr double kMinPerceptualFPS = 1.0;
+constexpr double kMaxPerceptualFPS = 144.0;
+
+double ClampPerceptualFPS(double fps)
+{
+    return std::clamp(fps, kMinPerceptualFPS, kMaxPerceptualFPS);
+}
+} // namespace
 
 // Async destruction of a clip. The destructor may be delayed by a
 // catch up streaming mechanism for caching
@@ -1060,8 +1072,8 @@ void CPlayer::PlayNextDream(bool quickFade) {
 }
 
 
-void CPlayer::MultiplyPerceptualFPS(const double _multiplier) {
-    m_PerceptualFPS *= _multiplier;
+void CPlayer::MultiplyPerceptualFPS(const double _multiplier){
+    m_PerceptualFPS = ClampPerceptualFPS(m_PerceptualFPS * _multiplier);
 
     reader_lock l(m_UpdateMutex);
     if (m_currentClip) {
@@ -1075,9 +1087,9 @@ void CPlayer::MultiplyPerceptualFPS(const double _multiplier) {
     }
 }
 
-void CPlayer::SetPerceptualFPS(const double _fps) {
+void CPlayer::SetPerceptualFPS(const double _fps){
 
-    m_PerceptualFPS = _fps;
+    m_PerceptualFPS = ClampPerceptualFPS(_fps);
 
     reader_lock l(m_UpdateMutex);
 

--- a/client_generic/Client/client.h
+++ b/client_generic/Client/client.h
@@ -658,10 +658,12 @@ class CElectricSheep
     
     void SetupFramerate()
     {
-        m_PerceptualFPS = g_Settings()->Get("settings.player.perceptual_fps", 20.);
+        m_PerceptualFPS =
+            g_Settings()->Get("settings.player.perceptual_fps", 20.);
 
         // We give the perceptual FPS to the player, and it is its job to adjust it with dream level
         g_Player().SetPerceptualFPS(m_PerceptualFPS);
+        m_PerceptualFPS = g_Player().GetPerceptualFPS();
     }
     
     void SetupProxy()


### PR DESCRIPTION
Fixes #562 

Adds min/max clamping to perceptual FPS so repeated playback speed inputs cannot produce runaway values.

The upper bound is set to 144 FPS, matching common high-refresh displays while staying well above typical playback requirements.