### PR TITLE
Fix Linux remote control commands and OSD display

### DIFF
--- a/client_generic/Client/client.h
+++ b/client_generic/Client/client.h
@@ -266,11 +266,7 @@ class CElectricSheep
 
         //	Trigger this to exist in the settings.
         // We reset the installdir at launch here, ensuring the bundle can be moved around
-#ifndef LINUX_GNU
         g_Settings()->Set("settings.app.InstallDir", m_WorkingDir);
-#else
-        g_Settings()->Set("settings.app.InstallDir", std::string(SHAREDIR));
-#endif
         g_Settings()->Storage()->Commit();
         return true;
     }

--- a/client_generic/Client/client_linux.h
+++ b/client_generic/Client/client_linux.h
@@ -239,6 +239,7 @@ class CElectricSheep_Linux : public CElectricSheep
             }
         }
 
+        ProcessCommandQueue();
         return true;
     }
 

--- a/client_generic/LinuxBuild/CMakeLists.txt
+++ b/client_generic/LinuxBuild/CMakeLists.txt
@@ -322,8 +322,8 @@ endif()
 
 # Copy runtime assets next to the binary
 add_custom_command(TARGET infinidream POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${BASE}/Runtime/logo.png
-        $<TARGET_FILE_DIR:infinidream>/logo.png
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${BASE}/Runtime
+        $<TARGET_FILE_DIR:infinidream>
     COMMENT "Copying runtime assets to binary directory"
 )

--- a/client_generic/MacBuild/OSD.hpp
+++ b/client_generic/MacBuild/OSD.hpp
@@ -268,6 +268,7 @@ public:
         // Fix A/R
         DisplayOutput::spCDisplayOutput spDisplay = g_Player().Display();
         float aspect = (spDisplay && spDisplay->Width() != 0) ? spDisplay->Aspect() : 1.0f;
+        const float kOsdYCenter = 0.1f; // Vertical center of OSD (0=top, 1=bottom)
         const float s_mini = 0.045f;  // This can be changed to adjust the overall scale of the mini OSD
 
         m_BgSqCRect = rect;
@@ -277,9 +278,9 @@ public:
         auto h_bgsq = m_BgSqCRect.Height();
         
         m_BgSqCRect.m_X0 = 0.5f - (w_bgsq * s_mini);
-        m_BgSqCRect.m_Y0 = 0.75f - (h_bgsq * s_mini);
+        m_BgSqCRect.m_Y0 = kOsdYCenter - (h_bgsq * s_mini);
         m_BgSqCRect.m_X1 = 0.5f + (w_bgsq * s_mini);
-        m_BgSqCRect.m_Y1 = 0.75f + (h_bgsq * s_mini);
+        m_BgSqCRect.m_Y1 = kOsdYCenter + (h_bgsq * s_mini);
 
         m_LargeSymbolCRect = rect;
         m_LargeSymbolCRect.m_X1 *= aspect;
@@ -290,7 +291,7 @@ public:
 
         // Position as the first dot (16x45), 30px left, 30px bottom to our main rect (700x210)
         m_LargeSymbolCRect.m_X0 = 0.5f - (w_lgs) * s_lgs;
-        m_LargeSymbolCRect.m_Y0 = 0.75f - (h_lgs) * s_lgs;
+        m_LargeSymbolCRect.m_Y0 = kOsdYCenter - (h_lgs) * s_lgs;
         m_LargeSymbolCRect.m_X1 = m_LargeSymbolCRect.m_X0 + (2 * w_lgs * s_lgs);
         m_LargeSymbolCRect.m_Y1 = m_LargeSymbolCRect.m_Y0 + (2 * h_lgs * s_lgs);
 
@@ -306,9 +307,9 @@ public:
         const float s = 0.15f;  // This can be changed to adjust the overall scale of the OSD
         m_BgCRect = m_Rect;
         m_BgCRect.m_X0 = 0.5f - (m_Rect.Width() * s);
-        m_BgCRect.m_Y0 = 0.75f - (m_Rect.Height() * s);
+        m_BgCRect.m_Y0 = kOsdYCenter - (m_Rect.Height() * s);
         m_BgCRect.m_X1 = 0.5f + (m_Rect.Width() * s);
-        m_BgCRect.m_Y1 = 0.75f + (m_Rect.Height() * s);
+        m_BgCRect.m_Y1 = kOsdYCenter + (m_Rect.Height() * s);
         
         
         // Set dot size
@@ -327,7 +328,7 @@ public:
         
         // Position as the first dot (16x45), 30px left, 30px bottom to our main rect (700x210)
         m_DotCRect.m_X0 = 0.5 - m_BgCRect.Width() / 2 + m_BgCRect.Width() * 30 / 700;
-        m_DotCRect.m_Y0 = 0.75f + m_BgCRect.Height() * 30 / 210;
+        m_DotCRect.m_Y0 = kOsdYCenter + m_BgCRect.Height() * 30 / 210;
         m_DotCRect.m_X1 = m_DotCRect.m_X0 + (2 * w * s2_w);
         m_DotCRect.m_Y1 = m_DotCRect.m_Y0 + (2 * h * s2_h);
 
@@ -349,7 +350,7 @@ public:
         //m_SymbolCRect.m_X0 = 0.5 - m_BgCRect.Width() / 2 + m_BgCRect.Width() / 6;
         // TMP : center the symbol until we fix text
         m_SymbolCRect.m_X0 = 0.5f - (w*s3);
-        m_SymbolCRect.m_Y0 = 0.75f - m_BgCRect.Height() * 75 / 210;
+        m_SymbolCRect.m_Y0 = kOsdYCenter - m_BgCRect.Height() * 75 / 210;
         m_SymbolCRect.m_X1 = m_SymbolCRect.m_X0 + (2 * w * s3);
         m_SymbolCRect.m_Y1 = m_SymbolCRect.m_Y0 + (2 * h * s3);
 


### PR DESCRIPTION
Remote commands (next, previous, faster, etc.) sent from the mobile app were being received and enqueued via the Socket.IO WebSocket connection but never executed on Linux.

Fixes:

1. ProcessCommandQueue() not called on Linux (client_linux.h) The Linux HandleEvents() override processed display events but omitted the ProcessCommandQueue() call present in both the base class and the Windows override. Commands sat in the queue forever and were silently discarded each frame.

2. InstallDir set to './' instead of the executable directory (client.h) InitStorage() had a LINUX_GNU branch that hardcoded InstallDir to SHAREDIR ('./') rather than m_WorkingDir. Since OSD textures are loaded relative to InstallDir at construction time, every texture load silently failed and the OSD rendered as an invisible/empty overlay. Removed the platform guard so all platforms consistently use m_WorkingDir, which the Linux Startup() already sets correctly to PlatformUtils::GetWorkingDir().

3. OSD runtime assets not copied to build directory (CMakeLists.txt) The post-build copy step only copied logo.png. All OSD textures (osd-bg-700.png, osd-pill.png, osd-next.png, etc.) and other runtime assets (network.png, Lato-Regular.ttf, etc.) were missing from the build directory, causing silent load failures. Switched from a single copy_if_different for logo.png to copy_directory for the entire Runtime/ folder so all assets stay in sync automatically.

4. OSD vertical position moved from 0.75 to 0.1 (OSD.hpp) The hardcoded 0.75f Y-center placed the OSD awkwardly two-thirds down the screen. Replaced all seven occurrences with a named constant kOsdYCenter = 0.1f, positioning the overlay near the top of the screen where it reads as a notification banner without obstructing content. Easy to adjust by changing the single constant.

Mac and Windows builds are unaffected by changes 1-3. Change 4 affects all platforms via the shared OSD.hpp.