### PR TITLE
Linux/Wayland: respond to KWin compositor pings to prevent window des…

### DIFF
--- a/client_generic/DisplayOutput/Vulkan/DisplayVulkan.cpp
+++ b/client_generic/DisplayOutput/Vulkan/DisplayVulkan.cpp
@@ -11,11 +11,9 @@
 #include <cstring>
 #include <sys/select.h>
 #ifdef HAVE_WAYLAND
+#include <poll.h>
 #include <sys/mman.h>
 #include <unistd.h>
-#ifdef HAVE_LIBDECOR
-#include <poll.h>
-#endif
 #endif
 
 namespace DisplayOutput
@@ -1047,6 +1045,13 @@ void CDisplayVulkan::checkEvents()
             while (libdecor_dispatch(m_pLibdecorContext, 0) > 0) {}
         }
 #endif
+        while (wl_display_prepare_read(m_pWlDisplay) != 0)
+            wl_display_dispatch_pending(m_pWlDisplay);
+        struct pollfd pfd = { wl_display_get_fd(m_pWlDisplay), POLLIN, 0 };
+        if (poll(&pfd, 1, 0) > 0 && (pfd.revents & POLLIN))
+            wl_display_read_events(m_pWlDisplay);
+        else
+            wl_display_cancel_read(m_pWlDisplay);
         wl_display_dispatch_pending(m_pWlDisplay);
         return;
     }


### PR DESCRIPTION
…aturation

On KDE/KWin Wayland sessions the app window would lose colour saturation after a few seconds of playback. KWin periodically sends an xdg_wm_base ping event and desaturates any window that does not pong back promptly.

The pong handler (onXdgWmBasePing → xdg_wm_base_pong) was already wired up correctly, but it never fired because the per-frame pump in checkEvents() only called wl_display_dispatch_pending(), which drains events already in the in-memory queue without reading from the Wayland socket. KWin's ping bytes sat unread on the fd, no pong was sent, and KWin concluded the app was frozen.

Fix: replace the bare wl_display_dispatch_pending() call with the documented prepare_read / poll / read_events (or cancel_read) / dispatch_pending idiom. A non-blocking poll(timeout=0) on the Wayland socket fd is performed each frame; if data is available the socket is drained into the event queue before dispatching. This ensures pings are seen and pongs are sent every frame without ever blocking the render loop.

Also move #include <poll.h> out of the inner HAVE_LIBDECOR guard into the enclosing HAVE_WAYLAND block, since it is now needed for all Wayland builds regardless of libdecor.

Mac and Windows builds are unaffected (all changes are inside #ifdef HAVE_WAYLAND).

Fixes #628.