### PR TITLE
Linux: implement linear and cubic frame blending (Vulkan)

### DIFF
--- a/client_generic/DisplayOutput/Vulkan/RendererVulkan.cpp
+++ b/client_generic/DisplayOutput/Vulkan/RendererVulkan.cpp
@@ -80,6 +80,10 @@ CRendererVulkan::~CRendererVulkan()
     if (m_commandPool         != VK_NULL_HANDLE) vkDestroyCommandPool(m_device, m_commandPool, nullptr);
     if (m_pipeline            != VK_NULL_HANDLE) vkDestroyPipeline(m_device, m_pipeline, nullptr);
     if (m_pipelineLayout      != VK_NULL_HANDLE) vkDestroyPipelineLayout(m_device, m_pipelineLayout, nullptr);
+    if (m_pipelineLinear      != VK_NULL_HANDLE) vkDestroyPipeline(m_device, m_pipelineLinear, nullptr);
+    if (m_pipelineLayoutLinear!= VK_NULL_HANDLE) vkDestroyPipelineLayout(m_device, m_pipelineLayoutLinear, nullptr);
+    if (m_pipelineCubic       != VK_NULL_HANDLE) vkDestroyPipeline(m_device, m_pipelineCubic, nullptr);
+    if (m_pipelineLayoutCubic != VK_NULL_HANDLE) vkDestroyPipelineLayout(m_device, m_pipelineLayoutCubic, nullptr);
     if (m_descriptorPool      != VK_NULL_HANDLE) vkDestroyDescriptorPool(m_device, m_descriptorPool, nullptr);
     if (m_descriptorSetLayout != VK_NULL_HANDLE) vkDestroyDescriptorSetLayout(m_device, m_descriptorSetLayout, nullptr);
     if (m_defaultSampler      != VK_NULL_HANDLE) vkDestroySampler(m_device, m_defaultSampler, nullptr);
@@ -501,21 +505,12 @@ VkShaderModule CRendererVulkan::loadShader(const std::string& path)
 }
 
 // ---------------------------------------------------------------------------
-// Graphics pipeline
+// Graphics pipeline — shared helper that builds a VkPipeline from pre-loaded
+// shader modules and a pre-created pipeline layout.
 // ---------------------------------------------------------------------------
-bool CRendererVulkan::createPipeline()
+bool CRendererVulkan::buildGraphicsPipeline(VkShaderModule vert, VkShaderModule frag,
+                                             VkPipelineLayout layout, VkPipeline& outPipeline)
 {
-    std::string shaderDir = PlatformUtils::GetWorkingDir() + "shaders/";
-
-    VkShaderModule vert = loadShader(shaderDir + "quad.vert.spv");
-    VkShaderModule frag = loadShader(shaderDir + "quad.frag.spv");
-    if (vert == VK_NULL_HANDLE || frag == VK_NULL_HANDLE)
-    {
-        if (vert != VK_NULL_HANDLE) vkDestroyShaderModule(m_device, vert, nullptr);
-        if (frag != VK_NULL_HANDLE) vkDestroyShaderModule(m_device, frag, nullptr);
-        return false;
-    }
-
     VkPipelineShaderStageCreateInfo stages[2]{};
     stages[0].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stages[0].stage  = VK_SHADER_STAGE_VERTEX_BIT;
@@ -526,7 +521,6 @@ bool CRendererVulkan::createPipeline()
     stages[1].module = frag;
     stages[1].pName  = "main";
 
-    // Vertex input: binding 0, stride = sizeof(QuadVertex)
     VkVertexInputBindingDescription binding{};
     binding.binding   = 0;
     binding.stride    = sizeof(QuadVertex);
@@ -551,7 +545,6 @@ bool CRendererVulkan::createPipeline()
     inputAssembly.sType    = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
     inputAssembly.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 
-    // Dynamic viewport and scissor
     VkDynamicState dynStates[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
     VkPipelineDynamicStateCreateInfo dynState{};
     dynState.sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
@@ -574,7 +567,6 @@ bool CRendererVulkan::createPipeline()
     ms.sType                = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
     ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
 
-    // Alpha blending (src_alpha, one_minus_src_alpha)
     VkPipelineColorBlendAttachmentState blendAtt{};
     blendAtt.blendEnable         = VK_TRUE;
     blendAtt.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
@@ -591,20 +583,6 @@ bool CRendererVulkan::createPipeline()
     blend.attachmentCount = 1;
     blend.pAttachments    = &blendAtt;
 
-    // Push constants: screenWidth, screenHeight, r, g, b, a  = 6 floats = 24 bytes
-    VkPushConstantRange pcRange{};
-    pcRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
-    pcRange.offset     = 0;
-    pcRange.size       = sizeof(VkPushConstants);
-
-    VkPipelineLayoutCreateInfo plci{};
-    plci.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-    plci.setLayoutCount         = 1;
-    plci.pSetLayouts            = &m_descriptorSetLayout;
-    plci.pushConstantRangeCount = 1;
-    plci.pPushConstantRanges    = &pcRange;
-    vkCreatePipelineLayout(m_device, &plci, nullptr, &m_pipelineLayout);
-
     VkGraphicsPipelineCreateInfo pci{};
     pci.sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
     pci.stageCount          = 2;
@@ -616,15 +594,130 @@ bool CRendererVulkan::createPipeline()
     pci.pMultisampleState   = &ms;
     pci.pColorBlendState    = &blend;
     pci.pDynamicState       = &dynState;
-    pci.layout              = m_pipelineLayout;
+    pci.layout              = layout;
     pci.renderPass          = m_renderPass;
 
-    VkResult result = vkCreateGraphicsPipelines(m_device, VK_NULL_HANDLE, 1, &pci,
-                                                nullptr, &m_pipeline);
+    return vkCreateGraphicsPipelines(m_device, VK_NULL_HANDLE, 1, &pci,
+                                     nullptr, &outPipeline) == VK_SUCCESS;
+}
+
+// ---------------------------------------------------------------------------
+// No-blend pipeline (single texture at set=0)
+// ---------------------------------------------------------------------------
+bool CRendererVulkan::createPipeline()
+{
+    VkPushConstantRange pcRange{};
+    pcRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+    pcRange.offset     = 0;
+    pcRange.size       = sizeof(VkPushConstants);
+
+    VkPipelineLayoutCreateInfo plci{};
+    plci.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    plci.setLayoutCount         = 1;
+    plci.pSetLayouts            = &m_descriptorSetLayout;
+    plci.pushConstantRangeCount = 1;
+    plci.pPushConstantRanges    = &pcRange;
+    if (vkCreatePipelineLayout(m_device, &plci, nullptr, &m_pipelineLayout) != VK_SUCCESS)
+        return false;
+
+    std::string shaderDir = PlatformUtils::GetWorkingDir() + "shaders/";
+    VkShaderModule vert = loadShader(shaderDir + "quad.vert.spv");
+    VkShaderModule frag = loadShader(shaderDir + "quad.frag.spv");
+    if (vert == VK_NULL_HANDLE || frag == VK_NULL_HANDLE)
+    {
+        if (vert != VK_NULL_HANDLE) vkDestroyShaderModule(m_device, vert, nullptr);
+        if (frag != VK_NULL_HANDLE) vkDestroyShaderModule(m_device, frag, nullptr);
+        return false;
+    }
+
+    bool ok = buildGraphicsPipeline(vert, frag, m_pipelineLayout, m_pipeline);
     vkDestroyShaderModule(m_device, vert, nullptr);
     vkDestroyShaderModule(m_device, frag, nullptr);
+    return ok;
+}
 
-    return result == VK_SUCCESS;
+// ---------------------------------------------------------------------------
+// Linear frame-blend pipeline (2 frame textures at sets 1 and 2)
+// ---------------------------------------------------------------------------
+bool CRendererVulkan::createLinearBlendPipeline()
+{
+    // Three identical descriptor set layouts: set 0 (unused placeholder),
+    // set 1 (frame1), set 2 (frame2).
+    VkDescriptorSetLayout setLayouts[3] = {
+        m_descriptorSetLayout, m_descriptorSetLayout, m_descriptorSetLayout
+    };
+
+    VkPushConstantRange pcRange{};
+    pcRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+    pcRange.offset     = 0;
+    pcRange.size       = sizeof(VkPushConstantsLinear);
+
+    VkPipelineLayoutCreateInfo plci{};
+    plci.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    plci.setLayoutCount         = 3;
+    plci.pSetLayouts            = setLayouts;
+    plci.pushConstantRangeCount = 1;
+    plci.pPushConstantRanges    = &pcRange;
+    if (vkCreatePipelineLayout(m_device, &plci, nullptr, &m_pipelineLayoutLinear) != VK_SUCCESS)
+        return false;
+
+    std::string shaderDir = PlatformUtils::GetWorkingDir() + "shaders/";
+    VkShaderModule vert = loadShader(shaderDir + "quad.vert.spv");
+    VkShaderModule frag = loadShader(shaderDir + "blend_linear.frag.spv");
+    if (vert == VK_NULL_HANDLE || frag == VK_NULL_HANDLE)
+    {
+        if (vert != VK_NULL_HANDLE) vkDestroyShaderModule(m_device, vert, nullptr);
+        if (frag != VK_NULL_HANDLE) vkDestroyShaderModule(m_device, frag, nullptr);
+        return false;
+    }
+
+    bool ok = buildGraphicsPipeline(vert, frag, m_pipelineLayoutLinear, m_pipelineLinear);
+    vkDestroyShaderModule(m_device, vert, nullptr);
+    vkDestroyShaderModule(m_device, frag, nullptr);
+    if (ok) g_Log->Info("CRendererVulkan: linear frame-blend pipeline ready");
+    return ok;
+}
+
+// ---------------------------------------------------------------------------
+// Cubic frame-blend pipeline (4 frame textures at sets 1–4)
+// ---------------------------------------------------------------------------
+bool CRendererVulkan::createCubicBlendPipeline()
+{
+    // Five identical descriptor set layouts: set 0 (unused), sets 1–4 (frames).
+    VkDescriptorSetLayout setLayouts[5] = {
+        m_descriptorSetLayout, m_descriptorSetLayout, m_descriptorSetLayout,
+        m_descriptorSetLayout, m_descriptorSetLayout
+    };
+
+    VkPushConstantRange pcRange{};
+    pcRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+    pcRange.offset     = 0;
+    pcRange.size       = sizeof(VkPushConstantsCubic);
+
+    VkPipelineLayoutCreateInfo plci{};
+    plci.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    plci.setLayoutCount         = 5;
+    plci.pSetLayouts            = setLayouts;
+    plci.pushConstantRangeCount = 1;
+    plci.pPushConstantRanges    = &pcRange;
+    if (vkCreatePipelineLayout(m_device, &plci, nullptr, &m_pipelineLayoutCubic) != VK_SUCCESS)
+        return false;
+
+    std::string shaderDir = PlatformUtils::GetWorkingDir() + "shaders/";
+    VkShaderModule vert = loadShader(shaderDir + "quad.vert.spv");
+    VkShaderModule frag = loadShader(shaderDir + "blend_cubic.frag.spv");
+    if (vert == VK_NULL_HANDLE || frag == VK_NULL_HANDLE)
+    {
+        if (vert != VK_NULL_HANDLE) vkDestroyShaderModule(m_device, vert, nullptr);
+        if (frag != VK_NULL_HANDLE) vkDestroyShaderModule(m_device, frag, nullptr);
+        return false;
+    }
+
+    bool ok = buildGraphicsPipeline(vert, frag, m_pipelineLayoutCubic, m_pipelineCubic);
+    vkDestroyShaderModule(m_device, vert, nullptr);
+    vkDestroyShaderModule(m_device, frag, nullptr);
+    if (ok) g_Log->Info("CRendererVulkan: cubic frame-blend pipeline ready");
+    return ok;
 }
 
 // ---------------------------------------------------------------------------
@@ -879,6 +972,12 @@ bool CRendererVulkan::Initialize(spCDisplayOutput _spDisplay)
     if (!createWhiteTexture())                       return false;
     if (!createPipeline())                           return false;
     if (!createSyncObjects())                        return false;
+
+    // Blend pipelines are optional — failure is logged but does not abort startup.
+    if (!createLinearBlendPipeline())
+        g_Log->Warning("CRendererVulkan: linear blend pipeline unavailable (missing blend_linear.frag.spv?)");
+    if (!createCubicBlendPipeline())
+        g_Log->Warning("CRendererVulkan: cubic blend pipeline unavailable (missing blend_cubic.frag.spv?)");
     if (!createVertexBuffers())                      return false;
 
     m_currentDescSet = m_whiteDescSet;
@@ -926,7 +1025,11 @@ void CRendererVulkan::Reset(const uint32_t _flags)
     // previously-bound video/startup texture (which appeared as a ghost
     // ellipse over the F1/F2 HUD background rectangles).
     if (_flags & eTexture)
+    {
         m_currentDescSet = m_whiteDescSet;
+        for (int i = 0; i < MAX_BLEND_TEXTURES; ++i)
+            m_boundDescSets[i] = VK_NULL_HANDLE;
+    }
 }
 void CRendererVulkan::Apply()
 {
@@ -1085,8 +1188,9 @@ bool CRendererVulkan::BeginFrame()
     rpbi.pClearValues      = &clearColor;
     vkCmdBeginRenderPass(cmd, &rpbi, VK_SUBPASS_CONTENTS_INLINE);
 
-    // Bind pipeline + set viewport/scissor
+    // Bind default (no-blend) pipeline + set viewport/scissor
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipeline);
+    m_activePipeline = m_pipeline;
 
     VkViewport vp{};
     vp.width    = static_cast<float>(m_swapExtent.width);
@@ -1196,30 +1300,125 @@ void CRendererVulkan::DrawQuad(const Base::Math::CRect& _rect,
 
     VkCommandBuffer cmd = m_commandBuffers[m_currentFrame];
 
-    // Write vertices
     writeQuad(m_mappedVertex[m_currentFrame], m_vertexCount,
               _rect.m_X0, _rect.m_Y0, _rect.m_X1, _rect.m_Y1,
               _uvRect.m_X0, _uvRect.m_Y0, _uvRect.m_X1, _uvRect.m_Y1);
 
-    // Determine descriptor set: use currently selected texture or white
-    VkDescriptorSet ds = m_currentDescSet ? m_currentDescSet : m_whiteDescSet;
-    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                             m_pipelineLayout, 0, 1, &ds, 0, nullptr);
+    // Determine blend mode from the currently active shader.
+    CShaderVulkan* vkShader = dynamic_cast<CShaderVulkan*>(m_spActiveShader.get());
+    CShaderVulkan::BlendMode blendMode =
+        vkShader ? vkShader->GetBlendMode() : CShaderVulkan::kNone;
 
-    // Push constants
-    VkPushConstants pc{};
-    pc.screenWidth  = static_cast<float>(m_swapExtent.width);
-    pc.screenHeight = static_cast<float>(m_swapExtent.height);
-    pc.r = _color.m_X; pc.g = _color.m_Y;
-    pc.b = _color.m_Z; pc.a = _color.m_W;
-    vkCmdPushConstants(cmd, m_pipelineLayout,
-                       VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
-                       0, sizeof(pc), &pc);
+    // Fall back to no-blend if the requested blend pipeline is unavailable.
+    if (blendMode == CShaderVulkan::kLinear && m_pipelineLinear == VK_NULL_HANDLE)
+    {
+        g_Log->Warning("CRendererVulkan: linear blend requested but pipeline unavailable — falling back");
+        blendMode = CShaderVulkan::kNone;
+    }
+    if (blendMode == CShaderVulkan::kCubic  && m_pipelineCubic  == VK_NULL_HANDLE)
+    {
+        g_Log->Warning("CRendererVulkan: cubic blend requested but pipeline unavailable — falling back");
+        blendMode = CShaderVulkan::kNone;
+    }
 
-    // Bind vertex buffer and draw
+    // Log the first draw call for each blend mode so it is easy to confirm
+    // blending is active without having to eyeball the output.
+    static bool s_loggedLinear = false;
+    static bool s_loggedCubic  = false;
+    if (blendMode == CShaderVulkan::kLinear && !s_loggedLinear)
+    {
+        g_Log->Info("CRendererVulkan: first linear frame-blend draw (delta=%.3f)",
+                    vkShader ? vkShader->GetFloat("delta") : 0.f);
+        s_loggedLinear = true;
+    }
+    else if (blendMode == CShaderVulkan::kCubic && !s_loggedCubic)
+    {
+        float w[4] = {};
+        if (vkShader) vkShader->GetFloat4("weights", w);
+        g_Log->Info("CRendererVulkan: first cubic frame-blend draw (weights=%.3f,%.3f,%.3f,%.3f)",
+                    w[0], w[1], w[2], w[3]);
+        s_loggedCubic = true;
+    }
+
+    VkPipeline       targetPipeline = m_pipeline;
+    VkPipelineLayout targetLayout   = m_pipelineLayout;
+    if (blendMode == CShaderVulkan::kLinear)
+    {
+        targetPipeline = m_pipelineLinear;
+        targetLayout   = m_pipelineLayoutLinear;
+    }
+    else if (blendMode == CShaderVulkan::kCubic)
+    {
+        targetPipeline = m_pipelineCubic;
+        targetLayout   = m_pipelineLayoutCubic;
+    }
+
+    if (targetPipeline != m_activePipeline)
+    {
+        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, targetPipeline);
+        m_activePipeline = targetPipeline;
+    }
+
+    const float sw = static_cast<float>(m_swapExtent.width);
+    const float sh = static_cast<float>(m_swapExtent.height);
+
+    if (blendMode == CShaderVulkan::kLinear)
+    {
+        VkDescriptorSet safe1 = m_boundDescSets[1] ? m_boundDescSets[1] : m_whiteDescSet;
+        VkDescriptorSet safe2 = m_boundDescSets[2] ? m_boundDescSets[2] : m_whiteDescSet;
+        VkDescriptorSet sets[3] = { m_whiteDescSet, safe1, safe2 };
+        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                 targetLayout, 0, 3, sets, 0, nullptr);
+
+        VkPushConstantsLinear pc{};
+        pc.screenWidth  = sw;   pc.screenHeight = sh;
+        pc.r = _color.m_X;      pc.g = _color.m_Y;
+        pc.b = _color.m_Z;      pc.a = _color.m_W;
+        pc.delta = vkShader ? vkShader->GetFloat("delta") : 0.f;
+        vkCmdPushConstants(cmd, targetLayout,
+                           VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
+                           0, sizeof(pc), &pc);
+    }
+    else if (blendMode == CShaderVulkan::kCubic)
+    {
+        VkDescriptorSet safe1 = m_boundDescSets[1] ? m_boundDescSets[1] : m_whiteDescSet;
+        VkDescriptorSet safe2 = m_boundDescSets[2] ? m_boundDescSets[2] : m_whiteDescSet;
+        VkDescriptorSet safe3 = m_boundDescSets[3] ? m_boundDescSets[3] : m_whiteDescSet;
+        VkDescriptorSet safe4 = m_boundDescSets[4] ? m_boundDescSets[4] : m_whiteDescSet;
+        VkDescriptorSet sets[5] = { m_whiteDescSet, safe1, safe2, safe3, safe4 };
+        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                 targetLayout, 0, 5, sets, 0, nullptr);
+
+        float weights[4] = {0.f, 0.f, 0.f, 0.f};
+        if (vkShader) vkShader->GetFloat4("weights", weights);
+
+        VkPushConstantsCubic pc{};
+        pc.screenWidth  = sw;   pc.screenHeight = sh;
+        pc.r = _color.m_X;      pc.g = _color.m_Y;
+        pc.b = _color.m_Z;      pc.a = _color.m_W;
+        pc.w0 = weights[0];     pc.w1 = weights[1];
+        pc.w2 = weights[2];     pc.w3 = weights[3];
+        vkCmdPushConstants(cmd, targetLayout,
+                           VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
+                           0, sizeof(pc), &pc);
+    }
+    else
+    {
+        VkDescriptorSet ds = m_currentDescSet ? m_currentDescSet : m_whiteDescSet;
+        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                 targetLayout, 0, 1, &ds, 0, nullptr);
+
+        VkPushConstants pc{};
+        pc.screenWidth  = sw;   pc.screenHeight = sh;
+        pc.r = _color.m_X;      pc.g = _color.m_Y;
+        pc.b = _color.m_Z;      pc.a = _color.m_W;
+        vkCmdPushConstants(cmd, targetLayout,
+                           VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
+                           0, sizeof(pc), &pc);
+    }
+
     VkDeviceSize offset = 0;
     vkCmdBindVertexBuffers(cmd, 0, 1, &m_vertexBuffer[m_currentFrame], &offset);
-    // Draw the 6 vertices we just wrote (offset into the mapped buffer)
     uint32_t firstVertex = m_vertexCount - 6;
     vkCmdDraw(cmd, 6, 1, firstVertex, 0);
 }
@@ -1371,10 +1570,33 @@ void CRendererVulkan::DrawText(spCBaseText _text,
 // Shaders
 // ---------------------------------------------------------------------------
 spCShader CRendererVulkan::NewShader(
-    const char* /*_pVert*/, const char* /*_pFrag*/,
-    std::vector<std::pair<std::string, eUniformType>> /*uniforms*/)
+    const char* /*_pVert*/, const char* _pFrag,
+    std::vector<std::pair<std::string, eUniformType>> uniforms)
 {
-    return std::make_shared<CShaderVulkan>();
+    auto shader = std::make_shared<CShaderVulkan>();
+
+    // Populate the uniforms map so CShader::Set() can store values that
+    // DrawQuad reads back when building push constants.
+    for (auto& [name, type] : uniforms)
+        shader->AddUniform(name, type);
+
+    // Choose blend mode from the symbolic fragment shader name.
+    if (_pFrag)
+    {
+        std::string frag(_pFrag);
+        if (frag == "drawDecodedFrameLinearFrameBlendFragment")
+        {
+            shader->SetBlendMode(CShaderVulkan::kLinear);
+            g_Log->Info("CRendererVulkan: created linear blend shader");
+        }
+        else if (frag == "drawDecodedFrameCubicFrameBlendFragment")
+        {
+            shader->SetBlendMode(CShaderVulkan::kCubic);
+            g_Log->Info("CRendererVulkan: created cubic blend shader");
+        }
+    }
+
+    return shader;
 }
 
 } // namespace DisplayOutput

--- a/client_generic/DisplayOutput/Vulkan/RendererVulkan.h
+++ b/client_generic/DisplayOutput/Vulkan/RendererVulkan.h
@@ -17,17 +17,35 @@ namespace DisplayOutput
 
 static const int MAX_FRAMES_IN_FLIGHT = 2;
 static const int MAX_QUADS_PER_FRAME  = 4096;
+// Number of texture slots tracked for multi-texture blending (slots 0–4).
+static const int MAX_BLEND_TEXTURES   = 5;
 
 struct QuadVertex {
     float x, y;
     float u, v;
 };
 
-// Push constants layout — must match quad.vert / quad.frag
+// Push constants for the no-blend pipeline — must match quad.vert / quad.frag.
 struct VkPushConstants {
     float screenWidth;
     float screenHeight;
     float r, g, b, a;
+};
+
+// Extended push constants for linear frame blending.
+struct VkPushConstantsLinear {
+    float screenWidth;
+    float screenHeight;
+    float r, g, b, a;
+    float delta;
+};
+
+// Extended push constants for cubic frame blending.
+struct VkPushConstantsCubic {
+    float screenWidth;
+    float screenHeight;
+    float r, g, b, a;
+    float w0, w1, w2, w3;
 };
 
 /*
@@ -61,9 +79,20 @@ class CRendererVulkan : public CRenderer
     VkDescriptorPool      m_descriptorPool      = VK_NULL_HANDLE;
     VkSampler             m_defaultSampler      = VK_NULL_HANDLE;
 
-    // Pipeline
+    // No-blend pipeline
     VkPipelineLayout m_pipelineLayout = VK_NULL_HANDLE;
     VkPipeline       m_pipeline       = VK_NULL_HANDLE;
+
+    // Linear frame-blend pipeline (2 textures at sets 1 and 2)
+    VkPipelineLayout m_pipelineLayoutLinear = VK_NULL_HANDLE;
+    VkPipeline       m_pipelineLinear       = VK_NULL_HANDLE;
+
+    // Cubic frame-blend pipeline (4 textures at sets 1–4)
+    VkPipelineLayout m_pipelineLayoutCubic = VK_NULL_HANDLE;
+    VkPipeline       m_pipelineCubic       = VK_NULL_HANDLE;
+
+    // Currently bound pipeline (tracked to avoid redundant vkCmdBindPipeline calls)
+    VkPipeline m_activePipeline = VK_NULL_HANDLE;
 
     // Command pool + buffers
     VkCommandPool                m_commandPool = VK_NULL_HANDLE;
@@ -89,25 +118,28 @@ class CRendererVulkan : public CRenderer
     uint32_t m_currentFrame      = 0;
     uint32_t m_currentImageIndex = 0;
     bool     m_inFrame           = false;
-    uint32_t m_vertexCount       = 0;   // vertices written this frame
+    uint32_t m_vertexCount       = 0;
 
-    // Currently active texture's descriptor set
+    // Per-slot descriptor sets for multi-texture rendering.
+    // Slot 0 mirrors m_currentDescSet; slots 1–4 hold blend frame textures.
+    VkDescriptorSet m_boundDescSets[MAX_BLEND_TEXTURES]{};
+
+    // Currently active texture's descriptor set (slot 0, backwards compat)
     VkDescriptorSet m_currentDescSet = VK_NULL_HANDLE;
 
     // Font pool
     std::map<std::string, spCBaseFont> m_fontPool;
 
     // ImGui state (Vulkan backend for text / UI overlay rendering)
-    VkInstance       m_vulkanInstance    = VK_NULL_HANDLE;  // stored for ImGui init
+    VkInstance       m_vulkanInstance    = VK_NULL_HANDLE;
     ImGuiContext*    m_imguiContext      = nullptr;
     bool             m_imguiInitialized = false;
 
     // GPU frame-time measurement via Vulkan timestamp queries.
-    // One start + one end query per in-flight slot → MAX_FRAMES_IN_FLIGHT * 2 queries total.
     VkQueryPool m_timestampPool    = VK_NULL_HANDLE;
     float       m_gpuFrameTimeMs   = 0.0f;
-    float       m_timestampPeriodNs = 0.0f;  // nanoseconds per timestamp tick
-    bool        m_timestampsValid  = false;   // becomes true after the first frame completes
+    float       m_timestampPeriodNs = 0.0f;
+    bool        m_timestampsValid  = false;
 
     // Initialisation helpers
     bool pickPhysicalDevice(VkInstance instance, VkSurfaceKHR surface);
@@ -119,6 +151,10 @@ class CRendererVulkan : public CRenderer
     bool createDescriptorPool();
     bool createSampler();
     bool createPipeline();
+    bool createLinearBlendPipeline();
+    bool createCubicBlendPipeline();
+    bool buildGraphicsPipeline(VkShaderModule vert, VkShaderModule frag,
+                               VkPipelineLayout layout, VkPipeline& outPipeline);
     bool createCommandPool();
     bool createCommandBuffers();
     bool createSyncObjects();
@@ -183,8 +219,14 @@ class CRendererVulkan : public CRenderer
     VkCommandBuffer BeginSingleTimeCommands();
     void            EndSingleTimeCommands(VkCommandBuffer cmd);
 
-    // Let the active texture set its descriptor
-    void SetDescriptorSet(VkDescriptorSet ds) { m_currentDescSet = ds; }
+    // Bind a texture's descriptor set at a specific slot.
+    // Slot 0 is used by no-blend draws; slots 1–4 are blend frame textures.
+    void SetDescriptorSet(VkDescriptorSet ds, uint32_t slot = 0)
+    {
+        if (slot < MAX_BLEND_TEXTURES)
+            m_boundDescSets[slot] = ds;
+        m_currentDescSet = ds;
+    }
 
     // Swapchain extent — used by CTextImGui::GetExtent() for screen-space normalisation
     VkExtent2D GetSwapExtent() const { return m_swapExtent; }

--- a/client_generic/DisplayOutput/Vulkan/ShaderVulkan.h
+++ b/client_generic/DisplayOutput/Vulkan/ShaderVulkan.h
@@ -11,8 +11,8 @@ namespace DisplayOutput
 {
 
 /*
-    CShaderUniformVulkan — stub; uniforms for Vulkan are push constants
-    managed by RendererVulkan directly.
+    CShaderUniformVulkan — stores a single uniform value in CPU memory.
+    The Vulkan renderer reads these values back when building push constants.
 */
 class CShaderUniformVulkan : public CShaderUniform
 {
@@ -35,21 +35,23 @@ class CShaderUniformVulkan : public CShaderUniform
 
     void Apply() override { m_bDirty = false; }
 
-    const void* Data()   const { return m_data.data(); }
-    size_t       Size()   const { return m_data.size(); }
+    const void* Data() const { return m_data.data(); }
+    size_t       Size() const { return m_data.size(); }
 };
 
 MakeSmartPointers(CShaderUniformVulkan);
 
 /*
-    CShaderVulkan — wraps a Vulkan pipeline handle.
-    For this renderer pipeline creation is centralised in CRendererVulkan;
-    this class is a thin handle so the base-class API is satisfied.
+    CShaderVulkan — thin handle satisfying the CShader interface.
+    Carries the blend mode and uniform values that CRendererVulkan reads in DrawQuad.
 */
 class CShaderVulkan : public CShader
 {
-    VkDevice   m_device   = VK_NULL_HANDLE;
-    VkPipeline m_pipeline = VK_NULL_HANDLE;
+  public:
+    enum BlendMode { kNone, kLinear, kCubic };
+
+  private:
+    BlendMode m_blendMode = kNone;
 
   public:
     CShaderVulkan() {}
@@ -61,12 +63,42 @@ class CShaderVulkan : public CShader
 
     bool Build(const char* /*_pVert*/, const char* /*_pFrag*/) override
     {
-        // Pipeline building is handled by CRendererVulkan::NewShader()
         return true;
     }
 
-    VkPipeline Pipeline() const { return m_pipeline; }
-    void SetPipeline(VkPipeline p) { m_pipeline = p; }
+    void SetBlendMode(BlendMode m) { m_blendMode = m; }
+    BlendMode GetBlendMode() const { return m_blendMode; }
+
+    // Register a named uniform so CShader::Set() can store its value.
+    void AddUniform(const std::string& name, eUniformType type)
+    {
+        m_Uniforms[name] = std::make_shared<CShaderUniformVulkan>(name, type);
+    }
+
+    // Read a float uniform value (e.g. "delta").
+    float GetFloat(const std::string& name) const
+    {
+        auto it = m_Uniforms.find(name);
+        if (it != m_Uniforms.end())
+        {
+            auto u = std::dynamic_pointer_cast<CShaderUniformVulkan>(it->second);
+            if (u && u->Size() >= sizeof(float))
+                return *static_cast<const float*>(u->Data());
+        }
+        return 0.f;
+    }
+
+    // Read a float4 uniform value (e.g. "weights") into a 4-element array.
+    void GetFloat4(const std::string& name, float out[4]) const
+    {
+        auto it = m_Uniforms.find(name);
+        if (it != m_Uniforms.end())
+        {
+            auto u = std::dynamic_pointer_cast<CShaderUniformVulkan>(it->second);
+            if (u && u->Size() >= 4 * sizeof(float))
+                memcpy(out, u->Data(), 4 * sizeof(float));
+        }
+    }
 };
 
 MakeSmartPointers(CShaderVulkan);

--- a/client_generic/DisplayOutput/Vulkan/TextureFlatVulkan.cpp
+++ b/client_generic/DisplayOutput/Vulkan/TextureFlatVulkan.cpp
@@ -321,12 +321,14 @@ bool CTextureFlatVulkan::uploadToImage(uint32_t w, uint32_t h)
 }
 
 // ---------------------------------------------------------------------------
-// Bind — tell the renderer to use this texture's descriptor set
+// Bind — register this texture's descriptor set at the given slot.
+// Slot 0 is used for single-texture (no-blend) draws; slots 1–4 hold the
+// frame textures consumed by the linear / cubic blend pipelines.
 // ---------------------------------------------------------------------------
-bool CTextureFlatVulkan::Bind(const uint32_t /*_index*/)
+bool CTextureFlatVulkan::Bind(const uint32_t _index)
 {
     if (m_descSet != VK_NULL_HANDLE)
-        m_pRenderer->SetDescriptorSet(m_descSet);
+        m_pRenderer->SetDescriptorSet(m_descSet, _index);
     m_dirty = false;
     return true;
 }

--- a/client_generic/DisplayOutput/Vulkan/shaders/blend_cubic.frag
+++ b/client_generic/DisplayOutput/Vulkan/shaders/blend_cubic.frag
@@ -1,0 +1,27 @@
+#version 450
+
+layout(location = 0) in vec2 fragUV;
+layout(location = 1) in vec4 fragColor;
+
+layout(location = 0) out vec4 outColor;
+
+layout(set = 1, binding = 0) uniform sampler2D frame1;
+layout(set = 2, binding = 0) uniform sampler2D frame2;
+layout(set = 3, binding = 0) uniform sampler2D frame3;
+layout(set = 4, binding = 0) uniform sampler2D frame4;
+
+layout(push_constant) uniform PC {
+    float screenWidth;
+    float screenHeight;
+    float r, g, b, a;
+    float w0, w1, w2, w3;
+} pc;
+
+void main()
+{
+    vec4 c1 = texture(frame1, fragUV);
+    vec4 c2 = texture(frame2, fragUV);
+    vec4 c3 = texture(frame3, fragUV);
+    vec4 c4 = texture(frame4, fragUV);
+    outColor = clamp(c1*pc.w0 + c2*pc.w1 + c3*pc.w2 + c4*pc.w3, 0.0, 1.0) * fragColor;
+}

--- a/client_generic/DisplayOutput/Vulkan/shaders/blend_linear.frag
+++ b/client_generic/DisplayOutput/Vulkan/shaders/blend_linear.frag
@@ -1,0 +1,23 @@
+#version 450
+
+layout(location = 0) in vec2 fragUV;
+layout(location = 1) in vec4 fragColor;
+
+layout(location = 0) out vec4 outColor;
+
+layout(set = 1, binding = 0) uniform sampler2D frame1;
+layout(set = 2, binding = 0) uniform sampler2D frame2;
+
+layout(push_constant) uniform PC {
+    float screenWidth;
+    float screenHeight;
+    float r, g, b, a;
+    float delta;
+} pc;
+
+void main()
+{
+    vec4 c1 = texture(frame1, fragUV);
+    vec4 c2 = texture(frame2, fragUV);
+    outColor = mix(c1, c2, pc.delta) * fragColor;
+}

--- a/client_generic/LinuxBuild/CMakeLists.txt
+++ b/client_generic/LinuxBuild/CMakeLists.txt
@@ -122,9 +122,25 @@ if(GLSLC)
         DEPENDS ${SHADER_SRC_DIR}/quad.frag
         COMMENT "Compiling quad.frag → SPIR-V"
     )
+    add_custom_command(
+        OUTPUT  ${SHADER_OUT_DIR}/blend_linear.frag.spv
+        COMMAND ${GLSLC} -o ${SHADER_OUT_DIR}/blend_linear.frag.spv
+                         ${SHADER_SRC_DIR}/blend_linear.frag
+        DEPENDS ${SHADER_SRC_DIR}/blend_linear.frag
+        COMMENT "Compiling blend_linear.frag → SPIR-V"
+    )
+    add_custom_command(
+        OUTPUT  ${SHADER_OUT_DIR}/blend_cubic.frag.spv
+        COMMAND ${GLSLC} -o ${SHADER_OUT_DIR}/blend_cubic.frag.spv
+                         ${SHADER_SRC_DIR}/blend_cubic.frag
+        DEPENDS ${SHADER_SRC_DIR}/blend_cubic.frag
+        COMMENT "Compiling blend_cubic.frag → SPIR-V"
+    )
     add_custom_target(compile_shaders ALL DEPENDS
         ${SHADER_OUT_DIR}/quad.vert.spv
         ${SHADER_OUT_DIR}/quad.frag.spv
+        ${SHADER_OUT_DIR}/blend_linear.frag.spv
+        ${SHADER_OUT_DIR}/blend_cubic.frag.spv
     )
 else()
     message(WARNING "glslc not found. Shaders will not be compiled automatically.")


### PR DESCRIPTION
Frame blending was already implemented for macOS (Metal) and Windows (DX11) but was silently disabled on Linux because the Vulkan renderer's NewShader() was a no-op stub and no blend shaders existed.

How it works
------------
The Vulkan renderer uses a multi-set descriptor approach: each decoded frame texture already has its own VkDescriptorSet (binding 0). For blend draws, the new pipelines declare multiple identical descriptor set layouts so the same per-texture sets can be bound at different set indices (set=1..2 for linear, set=1..4 for cubic) without any descriptor-set reallocation.

New files
---------
- shaders/blend_linear.frag  — mixes two RGBA frames via mix(c1,c2,delta)
- shaders/blend_cubic.frag   — combines four RGBA frames with
                               Mitchell-Netravali weights (w0..w3)

Both shaders are compiled to SPIR-V by the existing glslc CMake target.

C++ changes
-----------
ShaderVulkan.h
  CShaderVulkan gains a BlendMode enum (kNone/kLinear/kCubic), populates
  its m_Uniforms map so CShader::Set("delta",...) / Set("weights",...)
  actually store values, and exposes GetFloat/GetFloat4 for DrawQuad to
  read them back.

RendererVulkan.h / .cpp
  - createPipeline() refactored: common Vulkan pipeline boilerplate extracted into buildGraphicsPipeline() helper.
  - createLinearBlendPipeline(): 3-set layout, 28-byte push constants (base 24 + float delta).
  - createCubicBlendPipeline(): 5-set layout, 40-byte push constants (base 24 + float4 weights).
  - Blend pipelines are created after the main pipeline in Initialize(); failure logs a warning but does not abort startup (graceful fallback to no-blend).
  - NewShader() now sets the blend mode on the returned CShaderVulkan and populates its uniforms map; previously it returned an empty stub.
  - DrawQuad() detects the active shader's blend mode, switches pipeline via vkCmdBindPipeline if needed (tracked via m_activePipeline to avoid redundant calls), binds the per-slot descriptor sets, and pushes the appropriate extended push-constant struct.
  - m_boundDescSets[5] tracks descriptor sets per texture slot so slots 1-4 are available for blend frame textures.
  - Reset(eTexture) clears m_boundDescSets alongside m_currentDescSet.
  - Destructor cleans up the two new pipelines and layouts.

TextureFlatVulkan.cpp
  Bind(uint_32t _index) now forwards the slot index to SetDescriptorSet()
  so frame textures bound at slots 1-4 by CLinearFrameDisplay /
  CCubicFrameDisplay are tracked separately and available at draw time.

CMakeLists.txt
  Added glslc compilation rules for blend_linear.frag.spv and
  blend_cubic.frag.spv; both are included in the compile_shaders target
  and copied to the binary directory (and into the AppImage).

No changes to LinearFrameDisplay.h or CubicFrameDisplay.h — the Vulkan renderer already returns eMetal from Type(), so those switch cases were already matching and calling NewShader().

Diagnostics
-----------
Startup logs confirm both blend pipelines compiled on the GPU:
  "CRendererVulkan: linear frame-blend pipeline ready"
  "CRendererVulkan: cubic frame-blend pipeline ready"

The first draw call for each blend mode logs the active uniform values:
  "CRendererVulkan: first linear frame-blend draw (delta=0.xxx)"
  "CRendererVulkan: first cubic frame-blend draw (weights=...)"