### PR TITLE
Fix #620: Linux client should use Lato font with drop-shadow

### DIFF
--- a/client_generic/Client/client.h
+++ b/client_generic/Client/client.h
@@ -379,11 +379,11 @@ class CElectricSheep
 #endif
             "Keyboard Commands:\n"
             BK("A") ": Slower playback\t\t\t\t" BK("Up") ": Like this dream\n"
-            BK("D") ": Faster playback\t\t\t\t" BK("Down") ": Dislike and delete\n"
+            BK("D") ": Faster playback\t\t\t\t\t" BK("Down") ": Dislike and delete\n"
             BK("J") ": Skip 10 seconds back\t\t\t" BK("Left") ": Previous dream\n"
             BK("L") ": Skip 10 seconds forward\t\t" BK("Right") ": Next dream\n"
             BK("R") ": Repeat current dream\t\t\t" BK("H") ": Shuffle mode\n"
-            BK("C") ": Show credit\t\t\t\t\t" BK("B") ": Report this dream\n"
+            BK("C") ": Show credit\t\t\t\t\t\t" BK("B") ": Report this dream\n"
 #ifdef LINUX_GNU
             BK("V") ": Open web source\t\t\t\t" BK("F") ": Toggle full screen\n"
 #else
@@ -393,7 +393,11 @@ class CElectricSheep
 
             BK(FULLSCREEN_MODIFIER_KEY "-R") ": Open remote control\n"
             BK(FULLSCREEN_MODIFIER_KEY "-B") ": Browse playlists\n"
-            BK(FULLSCREEN_MODIFIER_KEY "-,") ": Open settings",
+            BK(FULLSCREEN_MODIFIER_KEY "-,") ": Open settings"
+#ifdef LINUX_GNU
+            "\n" BK(FULLSCREEN_MODIFIER_KEY "-Q") ": Quit"
+#endif
+            ,
             ""));
 #undef BK
 

--- a/client_generic/DisplayOutput/Vulkan/FontVulkan.cpp
+++ b/client_generic/DisplayOutput/Vulkan/FontVulkan.cpp
@@ -3,6 +3,7 @@
 #include "FontVulkan.h"
 #include "RendererVulkan.h"
 #include "Log.h"
+#include "PlatformUtils.h"
 
 #include <imgui.h>
 
@@ -12,27 +13,37 @@ namespace DisplayOutput
 // ---------------------------------------------------------------------------
 // CreateWithRenderer — register font with ImGui's global atlas.
 //
-// Uses ImGui's built-in embedded ProggyForever font (MIT license, no external
-// files required).  Bold is simulated with a small extra advance so key labels
-// in the F1 overlay sit visually apart from surrounding normal text.
+// Loads Lato-Regular.ttf from the binary directory (copied there by CMake).
+// Falls back to the embedded ProggyForever font if the file is not found.
 // ---------------------------------------------------------------------------
 bool CFontImGui::CreateWithRenderer(CRendererVulkan* /*renderer*/)
 {
-    m_fontSize = static_cast<float>(m_FontDescription.Height());
+    m_fontSizePx = static_cast<float>(m_FontDescription.Height());
     const bool isBold = m_FontDescription.Style() >= CFontDescription::Bold;
 
-    ImFontConfig cfg;
-    cfg.SizePixels = m_fontSize;
+    std::string fontPath = PlatformUtils::GetWorkingDir() + "Lato-Regular.ttf";
+    m_imFont = ImGui::GetIO().Fonts->AddFontFromFileTTF(fontPath.c_str(), m_fontSizePx);
+    if (m_imFont)
+    {
+        g_Log->Info("CFontImGui: loaded Lato-Regular.ttf at %.0fpx%s",
+                    m_fontSizePx, isBold ? " (bold)" : "");
+        return true;
+    }
 
+    g_Log->Warning("CFontImGui: Lato-Regular.ttf not found at %s, using embedded font",
+                   fontPath.c_str());
+
+    ImFontConfig cfg;
+    cfg.SizePixels = m_fontSizePx;
     m_imFont = ImGui::GetIO().Fonts->AddFontDefaultVector(&cfg);
     if (!m_imFont)
     {
-        g_Log->Warning("CFontImGui: AddFontDefaultVector failed at %.0fpx", m_fontSize);
+        g_Log->Warning("CFontImGui: AddFontDefaultVector also failed at %.0fpx", m_fontSizePx);
         return false;
     }
 
     g_Log->Info("CFontImGui: registered embedded font at %.0fpx%s",
-                m_fontSize, isBold ? " (bold)" : "");
+                m_fontSizePx, isBold ? " (bold)" : "");
     return true;
 }
 
@@ -66,8 +77,8 @@ Base::Math::CVector2 CTextImGui::GetExtent()
 
     static constexpr float kHudReferenceHeight = 1080.f;
     const float scale    = screenH / kHudReferenceHeight;
-    const float fontSize = spFI->FontSize() * scale;
-    ImVec2 sz = font->CalcTextSizeA(fontSize, FLT_MAX, 0.f, m_text.c_str());
+    const float fontSizePx = spFI->FontSize() * scale;
+    ImVec2 sz = font->CalcTextSizeA(fontSizePx, FLT_MAX, 0.f, m_text.c_str());
     return {sz.x / screenW, sz.y / screenH};
 }
 

--- a/client_generic/DisplayOutput/Vulkan/FontVulkan.h
+++ b/client_generic/DisplayOutput/Vulkan/FontVulkan.h
@@ -38,11 +38,11 @@ class CFontImGui : public CBaseFont
     bool CreateWithRenderer(CRendererVulkan* renderer);
 
     ImFont* GetImFont() const { return m_imFont; }
-    float   FontSize()  const { return m_fontSize; }
+    float   FontSize()  const { return m_fontSizePx; }
 
   private:
-    ImFont* m_imFont  = nullptr;
-    float   m_fontSize = 16.0f;
+    ImFont* m_imFont     = nullptr;
+    float   m_fontSizePx = 16.0f;
 };
 
 MakeSmartPointers(CFontImGui);

--- a/client_generic/DisplayOutput/Vulkan/RendererVulkan.cpp
+++ b/client_generic/DisplayOutput/Vulkan/RendererVulkan.cpp
@@ -1508,62 +1508,72 @@ void CRendererVulkan::DrawText(spCBaseText _text,
     // bake size — it rasterises at bake size and scales to display size.
     static constexpr float kHudReferenceHeight = 1080.f;
     const float scale    = static_cast<float>(m_spDisplay->Height()) / kHudReferenceHeight;
-    const float fontSize = spFI->FontSize() * scale;
+    const float fontSizePx = spFI->FontSize() * scale;
 
     // Convert normalised rect [0,1] → pixel coords (ImGui origin is top-left).
     Base::Math::CRect r = _text->GetRect();
     ImVec2 cursor{r.m_X0 * static_cast<float>(m_swapExtent.width),
                   r.m_Y0 * static_cast<float>(m_swapExtent.height)};
 
-    ImU32 col = ImGui::ColorConvertFloat4ToU32(
+    ImU32 col       = ImGui::ColorConvertFloat4ToU32(
         ImVec4(_color.m_X, _color.m_Y, _color.m_Z, _color.m_W));
+    ImU32 shadowCol = IM_COL32(0, 0, 0, static_cast<ImU32>(_color.m_W * 255.f));
 
     ImDrawList*        dl   = ImGui::GetBackgroundDrawList();
     const std::string& text = spTV->Text();
 
-    if (text.find_first_of("\t\n") == std::string::npos)
-    {
-        // Fast path — plain single-line text with no special characters.
-        dl->AddText(normalFont, fontSize, cursor, col, text.c_str());
-        return;
-    }
+    constexpr char newlineChar = '\n';
+    constexpr char tabChar     = '\t';
 
-    // Render segment-by-segment, handling:
-    //   \n — newline: reset cursor.x, advance cursor.y
-    //   \t — tab: snap cursor.x to next tab stop (4 × space width)
-    const float spaceW      = normalFont
-        ? normalFont->CalcTextSizeA(fontSize, FLT_MAX, 0.f, " ").x
-        : fontSize * 0.5f;
-    const float tabInterval = spaceW * 4.0f;
-    const float startX      = cursor.x;
-    const char* p           = text.c_str();
-    const char* segBegin    = p;
-
-    while (*p)
+    // Render text at 'origin' with 'color', handling \n and \t.
+    auto renderAt = [&](ImVec2 origin, ImU32 color)
     {
-        if (*p == '\n' || *p == '\t')
+        if (text.find_first_of({tabChar, newlineChar}) == std::string::npos)
         {
-            if (p > segBegin)
-            {
-                dl->AddText(normalFont, fontSize, cursor, col, segBegin, p);
-                cursor.x += normalFont->CalcTextSizeA(fontSize, FLT_MAX, 0.f, segBegin, p).x;
-            }
-            if (*p == '\n')
-            {
-                cursor.x = startX;
-                cursor.y += fontSize;
-            }
-            else
-            {
-                float offset = cursor.x - startX;
-                cursor.x = startX + (std::floor(offset / tabInterval) + 1.0f) * tabInterval;
-            }
-            segBegin = p + 1;
+            dl->AddText(normalFont, fontSizePx, origin, color, text.c_str());
+            return;
         }
-        ++p;
-    }
-    if (p > segBegin)
-        dl->AddText(normalFont, fontSize, cursor, col, segBegin, p);
+
+        // Segment-by-segment: \n resets to start of line, \t snaps to tab stop.
+        const float spaceW      = normalFont
+            ? normalFont->CalcTextSizeA(fontSizePx, FLT_MAX, 0.f, " ").x
+            : fontSizePx * 0.5f;
+        const float tabInterval = spaceW * 4.0f;
+        const float startX      = origin.x;
+        ImVec2      cur         = origin;
+        const char* p           = text.c_str();
+        const char* segBegin    = p;
+
+        while (*p)
+        {
+            if (*p == newlineChar || *p == tabChar)
+            {
+                if (p > segBegin)
+                {
+                    dl->AddText(normalFont, fontSizePx, cur, color, segBegin, p);
+                    cur.x += normalFont->CalcTextSizeA(fontSizePx, FLT_MAX, 0.f, segBegin, p).x;
+                }
+                if (*p == newlineChar)
+                {
+                    cur.x = startX;
+                    cur.y += fontSizePx;
+                }
+                else
+                {
+                    float offset = cur.x - startX;
+                    cur.x = startX + (std::floor(offset / tabInterval) + 1.0f) * tabInterval;
+                }
+                segBegin = p + 1;
+            }
+            ++p;
+        }
+        if (p > segBegin)
+            dl->AddText(normalFont, fontSizePx, cur, color, segBegin, p);
+    };
+
+    // Drop-shadow: 1 px down-right in black (matches Mac: shadowOffset=(1,-1), shadowRadius=0).
+    renderAt({cursor.x + 1.0f, cursor.y + 1.0f}, shadowCol);
+    renderAt(cursor, col);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Font
- CFontImGui::CreateWithRenderer now loads Lato-Regular.ttf from the binary directory (already copied there by CMake's POST_BUILD step) instead of the embedded ProggyForever font. Falls back to the embedded font if the file is not found. The AppImage build already copies the font into AppDir/usr/bin/ so it works there too.
- Rename m_fontSize → m_fontSizePx (member) and fontSize → fontSizePx (locals in DrawText / GetExtent) to make the unit (screen pixels) self-documenting.

Drop-shadow
- DrawText now renders each text string twice: first at cursor+(1,1)px in opaque black, then at the normal position in the requested colour. This matches the Mac CATextLayer shadow (shadowOffset=(1,-1), shadowRadius=0, shadowOpacity=1).
- Refactored DrawText to use a renderAt lambda so both the fast (plain single-line) and slow (multi-line \n/\t) paths share the same shadow+colour logic without duplication.
- newlineChar / tabChar constexpr constants hoisted to outer scope and used in find_first_of({tabChar, newlineChar}) for consistency.

F1 help overlay
- Added an extra tab before "Down: Dislike and delete" and "B: Report this dream" to improve right-column alignment.
- Added "Control-Q: Quit" entry after "Control-,: Open settings", guarded by #ifdef LINUX_GNU (Ctrl-Q is a Linux-only binding).