### PR TITLE
Add "Rotate On Portrait Displays" option (#623)

### DIFF
--- a/client_generic/Client/Player.cpp
+++ b/client_generic/Client/Player.cpp
@@ -362,6 +362,21 @@ void CPlayer::ForceWidthAndHeight(uint32_t du, uint32_t _w, uint32_t _h)
     }
 }
 
+void CPlayer::SetVideoRotation(uint32_t du, uint32_t _degrees)
+{
+    std::scoped_lock lockthis(m_displayListMutex);
+
+    if (du >= m_displayUnits.size())
+        return;
+
+    const std::shared_ptr<DisplayUnit> duptr = m_displayUnits[du];
+
+    if (duptr == nullptr || duptr->spRenderer == nullptr)
+        return;
+
+    duptr->spRenderer->SetVideoRotation((int)_degrees);
+}
+
 /*
 
 */

--- a/client_generic/Client/Player.h
+++ b/client_generic/Client/Player.h
@@ -271,7 +271,8 @@ class CPlayer : public Base::CSingleton<CPlayer>
         return static_cast<uint32_t>(m_displayUnits.size());
     }
     void ForceWidthAndHeight(uint32_t du, uint32_t _w, uint32_t _h);
-    
+    void SetVideoRotation(uint32_t du, uint32_t _degrees);
+
     void SetPaused(bool _bPaused, bool isUserInitiated = false) {
         bool stateChanged = (m_bPaused != _bPaused);
         m_bPaused = _bPaused;

--- a/client_generic/Client/SettingsDialogWin32.cpp
+++ b/client_generic/Client/SettingsDialogWin32.cpp
@@ -80,6 +80,7 @@ double g_playerFps = 23.0;
 double g_displayFps = 60.0;
 bool g_vsync = false;
 bool g_preserveAR = false;
+bool g_rotatePortrait = false;
 bool g_blackoutMonitors = true;
 bool g_quietMode = true;
 bool g_showAttribution = false;

--- a/client_generic/Client/SettingsDialogWin32/SettingsDialogWin32.CommonSettingsState.inl
+++ b/client_generic/Client/SettingsDialogWin32/SettingsDialogWin32.CommonSettingsState.inl
@@ -20,6 +20,7 @@ static void LoadSettingsForShow()
     g_displayFps = g_Settings()->Get("settings.player.display_fps", 60.0);
     g_vsync = g_Settings()->Get("settings.player.vbl_sync", false);
     g_preserveAR = g_Settings()->Get("settings.player.preserve_AR", false);
+    g_rotatePortrait = g_Settings()->Get("settings.player.rotate_portrait", false);
     g_blackoutMonitors = g_Settings()->Get("settings.player.blackout_monitors", true);
     g_quietMode = g_Settings()->Get("settings.player.quiet_mode", true);
     g_showAttribution = g_Settings()->Get("settings.app.attributionpng", false);
@@ -59,6 +60,7 @@ static void SaveSettings()
     g_Settings()->Set("settings.player.DisplayMode", 2);
     g_Settings()->Set("settings.player.vbl_sync", g_vsync);
     g_Settings()->Set("settings.player.preserve_AR", g_preserveAR);
+    g_Settings()->Set("settings.player.rotate_portrait", g_rotatePortrait);
     g_Settings()->Set("settings.player.blackout_monitors", g_blackoutMonitors);
     g_Settings()->Set("settings.player.quiet_mode", g_quietMode);
     g_Settings()->Set("settings.app.attributionpng", g_showAttribution);

--- a/client_generic/Client/SettingsDialogWin32/SettingsDialogWin32.TabDisplay.inl
+++ b/client_generic/Client/SettingsDialogWin32/SettingsDialogWin32.TabDisplay.inl
@@ -3,3 +3,6 @@ const float topPadding = S(80.f);
 
 ImGui::SetCursorPos(ImVec2(leftPadding, ImGui::GetCursorPosY() + topPadding));
 StyledCheckbox("Preserve Aspect Ratio", &g_preserveAR);
+
+ImGui::SetCursorPosX(leftPadding);
+StyledCheckbox("Rotate On Portrait Displays", &g_rotatePortrait);

--- a/client_generic/DisplayOutput/D3D11/DisplayDX11.cpp
+++ b/client_generic/DisplayOutput/D3D11/DisplayDX11.cpp
@@ -1266,7 +1266,7 @@ HWND CDisplayDX11::CreateDisplayWindow(uint32_t w, uint32_t h, bool fullscreen,
 
         auto clientSizeForPreserveAR = [&](uint32_t& cw, uint32_t& ch) {
             // Match D3D video region: drawable (cw × ch − title strip) stays 16:9 (see
-            // BuildBaseViewportForDisplay + ComputeAspectViewport16By9).
+            // BuildBaseViewportForDisplay + ComputeAspectViewport).
             if (!preserveAR || !customVideoTopInset)
                 return;
             const int tb = GetSystemTitlebarHeightPx();

--- a/client_generic/DisplayOutput/D3D11/RendererDX11.cpp
+++ b/client_generic/DisplayOutput/D3D11/RendererDX11.cpp
@@ -156,7 +156,8 @@ cbuffer QuadUniforms : register(b0) {
     float4 uvRect;
     float4 color;
     float brightness;
-    float3 padding;
+    int rotation;
+    float2 padding;
 };
 
 struct PSInput {
@@ -167,6 +168,7 @@ struct PSInput {
 float4 main(PSInput input) : SV_TARGET {
     float2 adjustedUV = (input.uv - rect.xy) / rect.zw;
     adjustedUV = uvRect.xy + adjustedUV * uvRect.zw;
+    if (rotation == 90) adjustedUV = float2(adjustedUV.y, 1.0 - adjustedUV.x);  // portrait rotation
     float4 sampled = tx0.Sample(smp0, adjustedUV);
     sampled.rgb += brightness;
     return float4(sampled.rgb * color.rgb, color.a);
@@ -185,7 +187,8 @@ cbuffer QuadUniforms : register(b0) {
     float4 uvRect;
     float4 color;
     float brightness;
-    float3 padding;
+    int rotation;
+    float2 padding;
 };
 
 cbuffer LinearDeltaCB : register(b1) {
@@ -201,6 +204,7 @@ struct PSInput {
 float4 main(PSInput input) : SV_TARGET {
     float2 adjustedUV = (input.uv - rect.xy) / rect.zw;
     adjustedUV = uvRect.xy + adjustedUV * uvRect.zw;
+    if (rotation == 90) adjustedUV = float2(adjustedUV.y, 1.0 - adjustedUV.x);  // portrait rotation
     float4 c1 = tx1.Sample(smp1, adjustedUV);
     float4 c2 = tx2.Sample(smp2, adjustedUV);
     float4 blended = lerp(c1, c2, delta);
@@ -240,7 +244,8 @@ cbuffer QuadUniforms : register(b0) {
     float4 uvRect;
     float4 color;
     float  brightness;
-    float3 padding;
+    int    rotation;
+    float2 padding;
 };
 
 struct PSInput { float4 position : SV_POSITION; float2 uv : TEXCOORD0; };
@@ -258,6 +263,7 @@ float4 SampleNV12(Texture2D yT, Texture2D uvT, SamplerState sY2, SamplerState sU
 float4 main(PSInput input) : SV_TARGET {
     float2 adjustedUV = (input.uv - rect.xy) / rect.zw;
     adjustedUV = uvRect.xy + adjustedUV * uvRect.zw;
+    if (rotation == 90) adjustedUV = float2(adjustedUV.y, 1.0 - adjustedUV.x);  // portrait rotation
     float4 c = SampleNV12(yTex, uvTex, sY, sUV, adjustedUV);
     c.rgb += brightness;
     return float4(c.rgb * color.rgb, color.a);
@@ -276,7 +282,7 @@ SamplerState s4 : register(s4);
 SamplerState s5 : register(s5);
 
 cbuffer QuadUniforms : register(b0) {
-    float4 rect; float4 uvRect; float4 color; float brightness; float3 padding;
+    float4 rect; float4 uvRect; float4 color; float brightness; int rotation; float2 padding;
 };
 cbuffer LinearDeltaCB : register(b1) { float delta; float3 _padDelta; };
 
@@ -295,6 +301,7 @@ float4 SampleNV12_2(Texture2D yT, Texture2D uvT, SamplerState sY2, SamplerState 
 float4 main(PSInput input) : SV_TARGET {
     float2 adjustedUV = (input.uv - rect.xy) / rect.zw;
     adjustedUV = uvRect.xy + adjustedUV * uvRect.zw;
+    if (rotation == 90) adjustedUV = float2(adjustedUV.y, 1.0 - adjustedUV.x);  // portrait rotation
     float4 c1 = SampleNV12_2(f1Y, f1UV, s2, s3, adjustedUV);
     float4 c2 = SampleNV12_2(f2Y, f2UV, s4, s5, adjustedUV);
     float4 blended = lerp(c1, c2, delta);
@@ -315,7 +322,7 @@ SamplerState s6 : register(s6);  SamplerState s7 : register(s7);
 SamplerState s8 : register(s8);  SamplerState s9 : register(s9);
 
 cbuffer QuadUniforms : register(b0) {
-    float4 rect; float4 uvRect; float4 color; float brightness; float3 padding;
+    float4 rect; float4 uvRect; float4 color; float brightness; int rotation; float2 padding;
 };
 cbuffer CubicWeightsCB : register(b1) { float4 weights; };
 
@@ -334,6 +341,7 @@ float4 SampleNV12_3(Texture2D yT, Texture2D uvT, SamplerState sY2, SamplerState 
 float4 main(PSInput input) : SV_TARGET {
     float2 adjustedUV = (input.uv - rect.xy) / rect.zw;
     adjustedUV = uvRect.xy + adjustedUV * uvRect.zw;
+    if (rotation == 90) adjustedUV = float2(adjustedUV.y, 1.0 - adjustedUV.x);  // portrait rotation
     float4 c1 = SampleNV12_3(f1Y, f1UV, s2, s3, adjustedUV);
     float4 c2 = SampleNV12_3(f2Y, f2UV, s4, s5, adjustedUV);
     float4 c3 = SampleNV12_3(f3Y, f3UV, s6, s7, adjustedUV);
@@ -360,7 +368,8 @@ cbuffer QuadUniforms : register(b0) {
     float4 uvRect;
     float4 color;
     float brightness;
-    float3 padding;
+    int rotation;
+    float2 padding;
 };
 
 cbuffer CubicWeightsCB : register(b1) {
@@ -375,6 +384,7 @@ struct PSInput {
 float4 main(PSInput input) : SV_TARGET {
     float2 adjustedUV = (input.uv - rect.xy) / rect.zw;
     adjustedUV = uvRect.xy + adjustedUV * uvRect.zw;
+    if (rotation == 90) adjustedUV = float2(adjustedUV.y, 1.0 - adjustedUV.x);  // portrait rotation
     float4 c1 = tx1.Sample(smp1, adjustedUV);
     float4 c2 = tx2.Sample(smp2, adjustedUV);
     float4 c3 = tx3.Sample(smp3, adjustedUV);
@@ -435,20 +445,23 @@ bool IsPreserveAspectEnabled()
     return g_Settings() && g_Settings()->Get("settings.player.preserve_AR", false);
 }
 
-bool ComputeAspectViewport16By9(float displayW, float displayH, D3D11_VIEWPORT& outViewport)
+// Compute a centered viewport of the given target aspect (width/height) inside the
+// display, letterboxing or pillarboxing as needed. targetAspect is 16:9 normally,
+// or 9:16 when the dream is rotated for a portrait display ("rotate_portrait").
+bool ComputeAspectViewport(float displayW, float displayH, float targetAspect,
+                           D3D11_VIEWPORT& outViewport)
 {
-    if (displayW <= 0.0f || displayH <= 0.0f)
+    if (displayW <= 0.0f || displayH <= 0.0f || targetAspect <= 0.0f)
         return false;
 
-    constexpr float kTargetAspect16By9 = 16.0f / 9.0f;
     const float displayAspect = displayW / displayH;
     float vpW = displayW;
     float vpH = displayH;
 
-    if (kTargetAspect16By9 > displayAspect)
-        vpH = std::max(1.0f, std::round(displayW / kTargetAspect16By9));
+    if (targetAspect > displayAspect)
+        vpH = std::max(1.0f, std::round(displayW / targetAspect));
     else
-        vpW = std::max(1.0f, std::round(displayH * kTargetAspect16By9));
+        vpW = std::max(1.0f, std::round(displayH * targetAspect));
 
     outViewport.TopLeftX = std::floor((displayW - vpW) * 0.5f);
     outViewport.TopLeftY = std::floor((displayH - vpH) * 0.5f);
@@ -2339,28 +2352,42 @@ void CRendererDX11::DrawTexturedQuad(const Base::Math::CRect& _rect,
 
     const CShaderDX11* selectedShaderDx11 =
         dynamic_cast<CShaderDX11*>(m_spSelectedShader.get());
-    const bool applyAspectViewport = selectedShaderDx11 &&
-                                     selectedShaderDx11->IsDecodedFrameShader() &&
-                                     IsPreserveAspectEnabled() && m_spDisplay;
+    const bool isDecodedFrame = selectedShaderDx11 &&
+                                selectedShaderDx11->IsDecodedFrameShader() && m_spDisplay;
 
     Base::Math::CRect drawRect = _rect;
     D3D11_VIEWPORT savedViewports[D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE] = {};
     UINT savedViewportCount = D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE;
     bool viewportOverridden = false;
+    int videoRotation = 0;
 
-    if (applyAspectViewport)
+    if (isDecodedFrame)
     {
         const D3D11_VIEWPORT baseVp = BuildBaseViewportForDisplay(m_spDisplay);
-        D3D11_VIEWPORT letterboxVp = {};
-        if (ComputeAspectViewport16By9(baseVp.Width, baseVp.Height, letterboxVp))
+
+        // "Rotate On Portrait Displays" (issue #623): when enabled and the display
+        // is taller than it is wide, turn the dream 90 deg (done in the decoded-frame
+        // shaders via QuadUniforms.rotation) and target a 9:16 box instead of 16:9.
+        // Mirrors the macOS path; applies to both the screensaver and fullscreen app.
+        const bool rotatePortrait =
+            g_Settings() && g_Settings()->Get("settings.player.rotate_portrait", false);
+        const bool shouldRotate = rotatePortrait && baseVp.Height > baseVp.Width;
+        videoRotation = shouldRotate ? 90 : 0;
+
+        if (IsPreserveAspectEnabled())
         {
-            // Offset the letterbox viewport into the reserved client region (e.g. below titlebar).
-            letterboxVp.TopLeftY += baseVp.TopLeftY;
-            m_context->RSGetViewports(&savedViewportCount, savedViewports);
-            m_context->RSSetViewports(1, &letterboxVp);
-            // Draw decoded frame across the computed viewport only.
-            drawRect = Base::Math::CRect(0.f, 0.f, 1.f, 1.f);
-            viewportOverridden = true;
+            const float targetAspect = shouldRotate ? (9.0f / 16.0f) : (16.0f / 9.0f);
+            D3D11_VIEWPORT letterboxVp = {};
+            if (ComputeAspectViewport(baseVp.Width, baseVp.Height, targetAspect, letterboxVp))
+            {
+                // Offset the letterbox viewport into the reserved client region (e.g. below titlebar).
+                letterboxVp.TopLeftY += baseVp.TopLeftY;
+                m_context->RSGetViewports(&savedViewportCount, savedViewports);
+                m_context->RSSetViewports(1, &letterboxVp);
+                // Draw decoded frame across the computed viewport only.
+                drawRect = Base::Math::CRect(0.f, 0.f, 1.f, 1.f);
+                viewportOverridden = true;
+            }
         }
     }
 
@@ -2380,7 +2407,8 @@ void CRendererDX11::DrawTexturedQuad(const Base::Math::CRect& _rect,
     uniforms->color[2] = _color.m_Z;
     uniforms->color[3] = _color.m_W;
     uniforms->brightness = GetBrightness();
-    uniforms->padding[0] = uniforms->padding[1] = uniforms->padding[2] = 0.0f;
+    uniforms->rotation = videoRotation;
+    uniforms->padding[0] = uniforms->padding[1] = 0.0f;
 
     m_context->Unmap(m_quadUniformBuffer.Get(), 0);
     ID3D11Buffer* cb = m_quadUniformBuffer.Get();

--- a/client_generic/DisplayOutput/D3D11/RendererDX11.h
+++ b/client_generic/DisplayOutput/D3D11/RendererDX11.h
@@ -88,7 +88,8 @@ private:
         float uvRect[4];
         float color[4];
         float brightness;
-        float padding[3];
+        int rotation;  // video rotation in degrees: 0 = none, 90 = rotate 90 CW
+        float padding[2];
     };
 
     struct Vertex

--- a/client_generic/DisplayOutput/Metal/MetalShaders.metal
+++ b/client_generic/DisplayOutput/Metal/MetalShaders.metal
@@ -60,6 +60,16 @@ fragment float4 drawTextureFragment(ColorInOut vert [[stage_in]],
     return float4(color.rgb * uniforms.color.rgb, alpha * color.a);
 }
 
+// Rotate texture-sampling coordinates about the (0.5, 0.5) center so a portrait
+// display can show landscape content turned 90 degrees. Only the decoded-frame
+// (video) fragment shaders call this; OSD/text rendering is left untouched.
+static inline float2 rotatedUV(float2 uv, int rotation)
+{
+    if (rotation == 90)
+        return float2(uv.y, 1.0 - uv.x);
+    return uv;
+}
+
 float4 SampleYUVTexturesRGBA(float2 uv,
                              texture2d<float, access::sample> yTexture,
                              texture2d<float, access::sample> uvTexture)
@@ -90,7 +100,8 @@ fragment float4 drawDecodedFrameNoBlendingFragment(
     texture2d<float, access::sample> uvTexture1 [[texture(1)]],
     constant QuadUniforms& uniforms [[buffer(0)]])
 {
-    float4 color = SampleYUVTexturesRGBA(vert.uv, yTexture1, uvTexture1);
+    float2 uv = rotatedUV(vert.uv, uniforms.rotation);
+    float4 color = SampleYUVTexturesRGBA(uv, yTexture1, uvTexture1);
     color.rgb += uniforms.brightness;
     return color * uniforms.color;
 }
@@ -111,8 +122,9 @@ fragment float4 drawDecodedFrameLinearFrameBlendFragment(
     constant QuadUniforms& uniforms [[buffer(0)]],
     constant LinearFrameBlendParameters& frameBlend [[buffer(1)]])
 {
-    float4 frame1RGBA = SampleYUVTexturesRGBA(vert.uv, frame1Y, frame1UV);
-    float4 frame2RGBA = SampleYUVTexturesRGBA(vert.uv, frame2Y, frame2UV);
+    float2 uv = rotatedUV(vert.uv, uniforms.rotation);
+    float4 frame1RGBA = SampleYUVTexturesRGBA(uv, frame1Y, frame1UV);
+    float4 frame2RGBA = SampleYUVTexturesRGBA(uv, frame2Y, frame2UV);
     float4 color = mix(frame1RGBA, frame2RGBA, frameBlend.delta);
     color.a = uniforms.color.a;
     color.rgb += uniforms.brightness;
@@ -199,10 +211,11 @@ fragment float4 drawDecodedFrameCubicFrameBlendFragment(
 #endif
     //return frameBlend.weights;
 
-    float4 c1 = SampleYUVTexturesRGBA(vert.uv, frame1Y, frame1UV);
-    float4 c2 = SampleYUVTexturesRGBA(vert.uv, frame2Y, frame2UV);
-    float4 c3 = SampleYUVTexturesRGBA(vert.uv, frame3Y, frame3UV);
-    float4 c4 = SampleYUVTexturesRGBA(vert.uv, frame4Y, frame4UV);
+    float2 uv = rotatedUV(vert.uv, uniforms.rotation);
+    float4 c1 = SampleYUVTexturesRGBA(uv, frame1Y, frame1UV);
+    float4 c2 = SampleYUVTexturesRGBA(uv, frame2Y, frame2UV);
+    float4 c3 = SampleYUVTexturesRGBA(uv, frame3Y, frame3UV);
+    float4 c4 = SampleYUVTexturesRGBA(uv, frame4Y, frame4UV);
     float4 color = (c1 * frameBlend.weights.x) + (c2 * frameBlend.weights.y) +
                    (c3 * frameBlend.weights.z) + (c4 * frameBlend.weights.w);
 

--- a/client_generic/DisplayOutput/Metal/RendererMetal.mm
+++ b/client_generic/DisplayOutput/Metal/RendererMetal.mm
@@ -445,6 +445,7 @@ void CRendererMetal::DrawQuad(const Base::Math::CRect& _rect,
                                         _uvrect.m_X1 - _uvrect.m_X0,
                                         _uvrect.m_Y1 - _uvrect.m_Y0};
         uniforms.brightness = m_Brightness;
+        uniforms.rotation = m_VideoRotation;
 
         [renderEncoder setFragmentBytes:&uniforms
                                  length:sizeof(uniforms)

--- a/client_generic/DisplayOutput/Metal/ShaderUniforms.h
+++ b/client_generic/DisplayOutput/Metal/ShaderUniforms.h
@@ -9,6 +9,7 @@ struct QuadUniforms
     vector_float4 uvRect;
     vector_float4 color;
     float brightness;
+    int rotation;  // video rotation in degrees: 0 = none, 90 = rotate 90 CW
 };
 
 #endif /* ShaderUniforms_h */

--- a/client_generic/DisplayOutput/Renderer/Renderer.cpp
+++ b/client_generic/DisplayOutput/Renderer/Renderer.cpp
@@ -10,7 +10,7 @@ namespace DisplayOutput
 
 /*
  */
-CRenderer::CRenderer() : m_Brightness(0) { m_bDirtyMatrices = 0; }
+CRenderer::CRenderer() : m_Brightness(0), m_VideoRotation(0) { m_bDirtyMatrices = 0; }
 
 /*
  */

--- a/client_generic/DisplayOutput/Renderer/Renderer.h
+++ b/client_generic/DisplayOutput/Renderer/Renderer.h
@@ -126,6 +126,7 @@ class CRenderer
     Base::Math::CMatrix4x4 m_WorldMat, m_ViewMat, m_ProjMat;
     uint32_t m_bDirtyMatrices;
     float m_Brightness;
+    int m_VideoRotation;  // degrees: 0 = none, 90 = rotate video 90 CW
 
   public:
     CRenderer();
@@ -202,6 +203,8 @@ class CRenderer
     {
         m_Brightness = _brightness;
     }
+    virtual int GetVideoRotation() const { return m_VideoRotation; }
+    virtual void SetVideoRotation(int _degrees) { m_VideoRotation = _degrees; }
 
     virtual eTextureTargetType GetTextureTargetType(void)
     {

--- a/client_generic/MacBuild/Base.lproj/SettingsDialog.xib
+++ b/client_generic/MacBuild/Base.lproj/SettingsDialog.xib
@@ -26,6 +26,7 @@
                 <outlet property="loginTestStatusText" destination="1099" id="1108"/>
                 <outlet property="okButton" destination="331" id="Qns-8w-LN7"/>
                 <outlet property="preserveAR" destination="1191" id="1193"/>
+                <outlet property="rotatePortrait" destination="Rp1-bt-n01" id="Rp3-ol-n03"/>
                 <outlet property="proxyHost" destination="Q3k-U6-7Ad" id="ALD-hu-lzP"/>
                 <outlet property="proxyLogin" destination="gY4-Mj-Ffb" id="vlU-Ky-EMd"/>
                 <outlet property="proxyPassword" destination="q9Y-KC-fux" id="7Jk-w6-4dx"/>
@@ -579,6 +580,13 @@ room for new ones</string>
                                                 <font key="font" metaFont="system"/>
                                             </buttonCell>
                                         </button>
+                                        <button toolTip="Check to rotate the dream 90 degrees on displays that are taller than they are wide (portrait orientation)." translatesAutoresizingMaskIntoConstraints="NO" id="Rp1-bt-n01">
+                                            <rect key="frame" x="158" y="166" width="200" height="18"/>
+                                            <buttonCell key="cell" type="check" title="Rotate On Portrait Displays" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="Rp2-cl-n02">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                        </button>
                                     </subviews>
                                     <constraints>
                                         <constraint firstItem="1041" firstAttribute="leading" secondItem="1040" secondAttribute="trailing" constant="8" symbolic="YES" id="EFn-CA-1Gv"/>
@@ -588,7 +596,9 @@ room for new ones</string>
                                         <constraint firstItem="1041" firstAttribute="firstBaseline" secondItem="1040" secondAttribute="firstBaseline" id="ctL-e2-R5i"/>
                                         <constraint firstItem="1191" firstAttribute="leading" secondItem="324" secondAttribute="leading" constant="160" id="m1n-dn-ySm"/>
                                         <constraint firstItem="1185" firstAttribute="top" secondItem="1041" secondAttribute="bottom" constant="24" id="m7d-8w-pdm"/>
-                                        <constraint firstItem="933" firstAttribute="top" secondItem="1191" secondAttribute="bottom" constant="8" id="mYm-6P-5kG"/>
+                                        <constraint firstItem="933" firstAttribute="top" secondItem="Rp1-bt-n01" secondAttribute="bottom" constant="8" id="mYm-6P-5kG"/>
+                                        <constraint firstItem="Rp1-bt-n01" firstAttribute="top" secondItem="1191" secondAttribute="bottom" constant="8" id="Rp4-tp-n04"/>
+                                        <constraint firstItem="Rp1-bt-n01" firstAttribute="leading" secondItem="324" secondAttribute="leading" constant="160" id="Rp5-ld-n05"/>
                                         <constraint firstItem="1191" firstAttribute="top" secondItem="1185" secondAttribute="bottom" constant="8" id="pGU-aw-jVg"/>
                                         <constraint firstItem="1185" firstAttribute="leading" secondItem="324" secondAttribute="leading" constant="200" id="pOq-Gj-AEO"/>
                                         <constraint firstItem="1041" firstAttribute="top" secondItem="324" secondAttribute="top" constant="20" symbolic="YES" id="s1g-o7-r9g"/>

--- a/client_generic/MacBuild/ESConfiguration.h
+++ b/client_generic/MacBuild/ESConfiguration.h
@@ -12,6 +12,7 @@
     IBOutlet NSButton* silentMode;
     IBOutlet NSButton* showAttribution;
     IBOutlet NSButton* preserveAR;
+    IBOutlet NSButton* rotatePortrait;
 
     // login buttons
     IBOutlet NSButton* signInButton;

--- a/client_generic/MacBuild/ESConfiguration.mm
+++ b/client_generic/MacBuild/ESConfiguration.mm
@@ -271,6 +271,9 @@
     preserveAR.state =
         ESScreensaver_GetBoolSetting("settings.player.preserve_AR", false);
 
+    rotatePortrait.state =
+        ESScreensaver_GetBoolSetting("settings.player.rotate_portrait", false);
+
     blackoutMonitors.state =
         ESScreensaver_GetBoolSetting("settings.player.blackout_monitors", true);
 
@@ -378,6 +381,9 @@
 
     ESScreensaver_SetBoolSetting("settings.player.preserve_AR",
                                  preserveAR.state);
+
+    ESScreensaver_SetBoolSetting("settings.player.rotate_portrait",
+                                 rotatePortrait.state);
 
     ESScreensaver_SetBoolSetting("settings.player.blackout_monitors",
                                  blackoutMonitors.state);

--- a/client_generic/MacBuild/ESScreensaver.cpp
+++ b/client_generic/MacBuild/ESScreensaver.cpp
@@ -109,6 +109,11 @@ void ESScreensaver_ForceWidthAndHeight(uint32 _width, uint32 _height)
     g_Player().ForceWidthAndHeight(0, _width, _height);
 }
 
+void ESScreensaver_SetVideoRotation(uint32 _degrees)
+{
+    g_Player().SetVideoRotation(0, _degrees);
+}
+
 void ESScreensaver_Deinit(void) { gClient.Shutdown(); }
 
 void ESScreensaver_AppendKeyEvent(DisplayOutput::CKeyEvent::eKeyCode keyCode)

--- a/client_generic/MacBuild/ESScreensaver.h
+++ b/client_generic/MacBuild/ESScreensaver.h
@@ -14,6 +14,7 @@ void ESScreensaver_Stop(void);
 void ESScreensaver_Resume(void);
 bool ESScreensaver_Stopped(void);
 void ESScreensaver_ForceWidthAndHeight(uint32_t _width, uint32_t _height);
+void ESScreensaver_SetVideoRotation(uint32_t _degrees);
 void ESScreensaver_Deinit(void);
 
 void ESScreensaver_AppendKeyEvent(DisplayOutput::CKeyEvent::eKeyCode keyCode);

--- a/client_generic/MacBuild/ESScreensaverView.mm
+++ b/client_generic/MacBuild/ESScreensaverView.mm
@@ -15,6 +15,7 @@
 {
     BOOL m_bStarted;
     BOOL m_bPausedForSheet;  // YES when paused for Preferences sheet (no full shutdown)
+    BOOL m_shouldRotate;     // YES when rotating the dream 90 deg for a portrait display
     int m_displayIdx;
 }
 
@@ -120,14 +121,24 @@
         newFrame.origin.x = 0.0;
         newFrame.origin.y = 0.0;
 
+        // "Rotate on portrait displays": when enabled and the screen is taller
+        // than it is wide, the dream is turned 90 deg (handled in the shader).
+        // The constrained box then targets 9:16 instead of 16:9.
+        m_shouldRotate =
+            ESScreensaver_GetBoolSetting("settings.player.rotate_portrait", false) &&
+            (frame.size.width < frame.size.height);
+
         if (ESScreensaver_GetBoolSetting("settings.player.preserve_AR", true)) {
-            if (newFrame.size.width/newFrame.size.height < (16.0f / 9.0f) )
+            float targetAR = m_shouldRotate ? (9.0f / 16.0f) : (16.0f / 9.0f);
+            if (newFrame.size.width / newFrame.size.height > targetAR)
             {
-                newFrame.size = CGSizeMake(newFrame.size.width, newFrame.size.width * 9.0f / 16.0f);
-                newFrame.origin.y = (frame.size.height - newFrame.size.height) / 2;
-            } else {
-                newFrame.size = CGSizeMake(newFrame.size.height * 16.0f / 9.0f, newFrame.size.height);
+                // Wider than the target box: constrain width, center horizontally.
+                newFrame.size = CGSizeMake(newFrame.size.height * targetAR, newFrame.size.height);
                 newFrame.origin.x = (frame.size.width - newFrame.size.width) / 2;
+            } else {
+                // Taller than the target box: constrain height, center vertically.
+                newFrame.size = CGSizeMake(newFrame.size.width, newFrame.size.width / targetAR);
+                newFrame.origin.y = (frame.size.height - newFrame.size.height) / 2;
             }
         }
 
@@ -202,6 +213,9 @@
 
         if (!ESScreensaver_Start(m_isPreview, width, height))
             return;
+
+        // Apply portrait rotation now that the renderer exists.
+        ESScreensaver_SetVideoRotation(m_shouldRotate ? 90 : 0);
 
 #ifdef SCREEN_SAVER
         g_Log->Info("Saver startAnimation on %f %f ", self.frame.size.width, self.frame.size.height);
@@ -335,48 +349,54 @@ static void signnal_handler(int signal)
 - (void)windowDidResize
 {
     NSRect videoFrame = self.frame;
-    
+
+    // "Rotate on portrait displays": when enabled and the display is taller
+    // than it is wide (aspect < 1), the dream is turned 90 degrees so the
+    // landscape content fits a portrait screen. The shader does the actual
+    // rotation; here we just pick the target box aspect (9:16 when rotated).
+    BOOL shouldRotate =
+        ESScreensaver_GetBoolSetting("settings.player.rotate_portrait", false) &&
+        (self.frame.size.width < self.frame.size.height);
+
+    // Set background to black for letterboxing/pillarboxing
+    if (self.window) {
+        self.window.backgroundColor = [NSColor blackColor];
+    }
+
     // Only apply aspect ratio constraint if the setting is enabled
     if (ESScreensaver_GetBoolSetting("settings.player.preserve_AR", true)) {
-        // Set background to black for letterboxing/pillarboxing
-        if (self.window) {
-            self.window.backgroundColor = [NSColor blackColor];
-        }
-
-        // Calculate 16:9 constrained frame within the window
         float frameAR = self.frame.size.width / self.frame.size.height;
-        float targetAR = 16.0f / 9.0f;
+        // Rotated content is 9:16; otherwise the dream is 16:9.
+        float targetAR = shouldRotate ? (9.0f / 16.0f) : (16.0f / 9.0f);
 
-        // Only adjust if aspect ratio differs significantly from 16:9
+        // Only adjust if aspect ratio differs significantly from the target
         if (fabsf(frameAR - targetAR) > 0.01f)
         {
             NSSize constrainedSize = self.frame.size;
 
-            if (frameAR < targetAR)  // Frame is taller than 16:9 (e.g., 16:10)
-            {
-                // Constrain height and center vertically
-                constrainedSize.height = constrainedSize.width * 9.0f / 16.0f;
-                CGFloat yOffset = (self.frame.size.height - constrainedSize.height) / 2.0f;
-                videoFrame = NSMakeRect(0, yOffset, constrainedSize.width, constrainedSize.height);
-            }
-            else  // Frame is wider than 16:9
+            if (frameAR > targetAR)  // Frame is wider than the target box
             {
                 // Constrain width and center horizontally
-                constrainedSize.width = constrainedSize.height * 16.0f / 9.0f;
+                constrainedSize.width = constrainedSize.height * targetAR;
                 CGFloat xOffset = (self.frame.size.width - constrainedSize.width) / 2.0f;
                 videoFrame = NSMakeRect(xOffset, 0, constrainedSize.width, constrainedSize.height);
+            }
+            else  // Frame is taller than the target box
+            {
+                // Constrain height and center vertically
+                constrainedSize.height = constrainedSize.width / targetAR;
+                CGFloat yOffset = (self.frame.size.height - constrainedSize.height) / 2.0f;
+                videoFrame = NSMakeRect(0, yOffset, constrainedSize.width, constrainedSize.height);
             }
         }
     } else {
         // When preserve AR is disabled, fill the entire window
-        if (self.window) {
-            self.window.backgroundColor = [NSColor blackColor];
-        }
         videoFrame = self.frame;
     }
 
     view.frame = videoFrame;
 
+    ESScreensaver_SetVideoRotation(shouldRotate ? 90 : 0);
     ESScreensaver_ForceWidthAndHeight((uint32_t)videoFrame.size.width,
                                       (uint32_t)videoFrame.size.height);
 }

--- a/client_generic/MacBuild/ESWindow.mm
+++ b/client_generic/MacBuild/ESWindow.mm
@@ -152,15 +152,26 @@ static void ShowFirstTimeSetupCallback()
 
     if (ESScreensaver_GetBoolSetting("settings.player.preserve_AR", true)) {
         // Calculate current screen aspect ratio
-        float screenAR = self.screen.frame.size.width / self.screen.frame.size.height;
-        
-        // set a fixed ratio on full screen
-        if (screenAR < (16.0f/9.0f))
-        {
-            [self setMaxFullScreenContentSize:CGSizeMake(self.screen.frame.size.width, self.screen.frame.size.width * 9 / 16)];
+        float screenW = self.screen.frame.size.width;
+        float screenH = self.screen.frame.size.height;
+        float screenAR = screenW / screenH;
 
+        // "Rotate on portrait displays": on a portrait screen the rotated dream
+        // is 9:16, so the fullscreen content box must be allowed to be portrait
+        // (otherwise it would stay a landscape strip and rotation couldn't fill).
+        BOOL shouldRotate =
+            ESScreensaver_GetBoolSetting("settings.player.rotate_portrait", false) &&
+            (screenAR < 1.0f);
+        float targetAR = shouldRotate ? (9.0f / 16.0f) : (16.0f / 9.0f);
+
+        // set a fixed ratio on full screen
+        if (screenAR > targetAR)
+        {
+            // Wider than the target box: constrain width.
+            [self setMaxFullScreenContentSize:CGSizeMake(screenH * targetAR, screenH)];
         } else {
-            [self setMaxFullScreenContentSize:CGSizeMake(self.screen.frame.size.height * 16 / 9, self.screen.frame.size.height)];
+            // Taller than the target box: constrain height.
+            [self setMaxFullScreenContentSize:CGSizeMake(screenW, screenW / targetAR)];
         }
     } else {
         // Clear any previous constraint to allow full stretch


### PR DESCRIPTION
﻿Part of #623 (macOS + Windows done; Linux still TODO).

## What

Adds a **"Rotate On Portrait Displays"** checkbox to the settings screen, next to "Preserve Aspect Ratio". Default unchecked. When enabled, any display whose aspect ratio is < 1 (taller than wide) shows the dream turned 90°, so 16:9 content fits a portrait screen.

## How

Aspect-ratio handling in this app works by sizing the Metal view to a centered box while the decoded-frame shaders sample the texture directly. So the fix has two coordinated parts:

1. **Shader rotation** — new `rotation` field on `QuadUniforms`, driven by a `m_VideoRotation` member on `CRenderer` (mirrors the existing `m_Brightness` pattern). The three decoded-frame fragment shaders rotate their sampling coordinates via a new `rotatedUV()` helper. OSD/text rendering is untouched.
2. **Geometry** — when rotating, the macOS view layer fits a **9:16** box instead of 16:9, respecting the Preserve AR checkbox (side bars on non-9:16 portrait screens when on; fill when off). The "should rotate" decision is made where the real screen size is known and pushed down via a new `ESScreensaver_SetVideoRotation` → `CPlayer::SetVideoRotation` bridge.

Applies to both the **screensaver** and the **standalone app** in fullscreen.

**Windows (DX11):** same feature — the six decoded-frame HLSL shaders rotate their sampling UV and `DrawTexturedQuad` targets a 9:16 box on portrait displays (no window plumbing needed); checkbox added to the Windows settings dialog. Builds clean and verified working.

## Files

- **Settings UI:** `SettingsDialog.xib`, `ESConfiguration.h/.mm` (`settings.player.rotate_portrait`)
- **Renderer/shader:** `ShaderUniforms.h`, `MetalShaders.metal`, `Renderer.h/.cpp`, `RendererMetal.mm`
- **Plumbing:** `ESScreensaver.h/.cpp`, `Player.h/.cpp`
- **Geometry:** `ESScreensaverView.mm`, `ESWindow.mm`

## Testing

- ✅ `infinidream App Stage` builds clean (Metal shader + C++ + Obj-C + XIB).
- ✅ `ScreenSaver Stage` builds clean (`SCREEN_SAVER` path / `ESMetalView`).
- ⏳ **Visual check still needed** on an actual portrait display (or by resizing the app window taller than wide): confirm the dream rotates and fills, the checkbox persists, and landscape displays are unaffected. If rotation comes out the wrong way, it's a one-line flip in `rotatedUV()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
