### PR TITLE
Fix #521: randomize download order in shuffle mode

### DIFF
--- a/client_generic/ContentDownloader/PlaylistManager.cpp
+++ b/client_generic/ContentDownloader/PlaylistManager.cpp
@@ -242,7 +242,23 @@ bool PlaylistManager::hasKeyframes() const {
 std::optional<std::string> PlaylistManager::getNextUncachedDream() const {
     Cache::CacheManager& cm = Cache::CacheManager::getInstance();
     auto& downloader = g_ContentDownloader().m_gDownloader;
-    
+
+    // In shuffle mode, playback order is random, so download order should be
+    // random too - don't follow keyframe chains or sequential successors (issue #521).
+    if (m_playbackMode == PlaybackMode::Shuffle) {
+        std::vector<std::string> uncached;
+        for (const auto& entry : m_playlist) {
+            if (!cm.hasDiskCachedItem(entry.uuid) &&
+                !downloader.IsDreamBeingDownloaded(entry.uuid)) {
+                uncached.push_back(entry.uuid);
+            }
+        }
+        if (uncached.empty())
+            return std::nullopt;
+        g_Log->Info("Shuffle mode: random uncached dream (%zu remaining)", uncached.size());
+        return uncached[rand() % uncached.size()];
+    }
+
     // Check if playlist has keyframes and randomly return an uncached dream 10% of the time
     if (hasKeyframes()) {
         // Generate random number between 0 and 99


### PR DESCRIPTION
## Problem

In shuffle mode, playback (`preflightNextDream()`) picks the next dream at random, but the background cache-fill downloader did not. `getNextUncachedDream()` ignored the playback mode entirely and always chose what to download next by following keyframe-successor chains or sequential `(idx+1)` successors. So in shuffle mode downloads "followed the keyframes or just followed along sequentially" instead of being random — exactly what #521 reports.

## Fix

Add an early branch at the top of `getNextUncachedDream()`: when the playback mode is `Shuffle`, return a uniformly random uncached dream and skip the keyframe/successor logic. Normal and Repeat modes are unchanged.

Uses `rand() % n` to match the random-selection style already used elsewhere in this file. (Filed #660 separately to standardize random-number generation across the codebase.)

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)