### PR TITLE
ACL tweaks for #666 

### DIFF
--- a/client_generic/Client/Player.cpp
+++ b/client_generic/Client/Player.cpp
@@ -746,7 +746,7 @@ bool CPlayer::Update(uint32_t displayUnit)
                 } else {
                     // Get the next dream decision
                     g_Log->Info("Update will preflight");
-                    // Natural transition - don't allow streaming
+                    // Natural transition - prefer cached (canStream=false still streams if the cache is totally empty).
                     m_nextDreamDecision = m_playlistManager->preflightNextDream(false);
                     
                     if (m_nextDreamDecision) {
@@ -1058,7 +1058,7 @@ void CPlayer::PlayNextDream(bool quickFade) {
         m_nextDreamDecision = std::nullopt;
     } else {
         // No preflight decision, get one now (fallback case)
-        // Natural transition - don't allow streaming
+        // Natural transition - prefer cached (canStream=false still streams if the cache is totally empty).
         auto nextDecision = m_playlistManager->preflightNextDream(false);
         if (nextDecision) {
             StartTransition();
@@ -1507,7 +1507,7 @@ void CPlayer::UpdateTransition(double currentTime)
         EDreamClient::SendStateUpdate();
     } else if (!m_nextClip) {
         // If we don't have a next clip yet, try to get one
-        // Natural transition fallback - don't allow streaming
+        // Natural transition fallback - prefer cached (canStream=false still streams if the cache is totally empty).
         auto nextDecision = m_playlistManager->preflightNextDream(false);
         if (nextDecision) {
             // We're in mid-transition without a next clip, must be user/network forced

--- a/client_generic/ContentDownloader/PlaylistManager.h
+++ b/client_generic/ContentDownloader/PlaylistManager.h
@@ -112,7 +112,8 @@ public:
 
     // Calculate what will be played next without changing state
     // canStream: if true, allows selecting dreams that aren't cached (will stream)
-    //            if false, only considers cached dreams
+    //            if false, prefers cached dreams but will still stream as a last resort
+    //            when the cache is completely empty (otherwise the caller busy-loops).
     // forceNext: if true, advances to next dream even in repeat mode (for explicit user "next" command)
     std::optional<NextDreamDecision> preflightNextDream(bool canStream = true, bool forceNext = false) const;
 

--- a/client_generic/TupleStorage/JSONStorage.cpp
+++ b/client_generic/TupleStorage/JSONStorage.cpp
@@ -103,6 +103,12 @@ bool JSONStorage::GetOrSetValue(
                 {
                     g_Log->Warning("JSONStorage: value for '%s' has unexpected type (%s); using default",
                                    std::string(_entry).c_str(), e.what());
+                    // On a write, repair the corrupt slot in place so the bad value
+                    // doesn't persist / recur on the next read.
+                    if (set)
+                    {
+                        _emplace(dict, token, _targetValue);
+                    }
                     return false;
                 }
             }


### PR DESCRIPTION
Small follow-ups stacked on top of #666 (commit 47f25e95). Intended to be merged onto fix-resume-busyloop-streaming-fallback; the PR is based on that branch so the diff is just these tweaks.

1. preflightNextDream now streams as a last resort when canStream=false and the cache is totally empty (the busyloop fix). The call-site comments and header doc still said "don't allow streaming", which is no longer accurate -- updated to reflect the fallback.

2. JSONStorage::GetOrSetValue: on the write path, returning false on exception left the corrupt value in place, while the wrapper Set methods return true unconditionally -- so callers saw a "successful" write that never happened and the bad value was persisted into Finalise. Repair the slot in place via _emplace on the set path so it doesn't recur.